### PR TITLE
MintAuthority as separate object to Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,19 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## [Unreleased]
 
 Added:
+- Moved the supply mint policy responsibility off the `Collection` object to a separate
+  object `MintAuthority`
 - `supply_policy` module with object `SupplyPolicy` to regulate NFT Collection supply
-- Substituted field `cap` by `supply_policy` from `Collection` object, making it
-  no longer a generic but an object of type `SupplyPolicy`
 - `std_collection::mint_and_transfer` function now expected `u64` for field `max_supply` instead
   of `Option<u64>` to facilitate function call on the client side
 
 Removed:
 - `cap` module with objects `Limited` and `Unlimited` that regulate the supply
   of NFT collections
+- Removed field `cap` from `Collection` object, removing the supply mint policy
+  responsibility off the `Collection` object
+  
+  no longer a generic but an object of type `SupplyPolicy`
 
 
 ## [0.4.0] - 2022-10-11

--- a/sources/collection/collection.move
+++ b/sources/collection/collection.move
@@ -1,13 +1,28 @@
-//! Module of a generic `Collection` type.
+//! Module of a generic `Collection` type and a `MintAuthority` type.
 //! 
 //! It acts as a generic interface for NFT Collections and it allows for
 //! the creation of arbitrary domain specific implementations.
 //! 
-//! NFT Collections can be of `Limited` or `Unlimited` supply `Cap`. The
-//! Collection `Cap` is an object that determines what the constrains are in
-//! relation to minting an NFT `Data` object associated to the Collection.
+//! The `MintAuthority` object gives power to the owner to mint objects.
+//! There is only one `MintAuthority` per `Collection`.
+//! The Mint Authority object contains a `SupplyPolicy` which
+//! can be regulated or unregulated.
+//! A Collection with unregulated Supply policy is a collection that
+//! does not keep track of its current supply objects. This allows for the
+//! minting process to be parallelized.
 //! 
-//! TODO: Consider adding a function `destroy_uncapped`?
+//! A Collection with regulated Supply policy is a collection that
+//! keeps track of its current supply objects. This means that whilst the 
+//! minting can be parallelized on the client side, on the blockchain side
+//! nodes will have to lock the `MintAuthority` object in order to mutate
+//! it sequentially. Regulated Supply allows for collections to have limited
+//! or unlimited supply. The `MintAuthority` owner can modify the 
+//! `max_supply` a posteriori, as long as the `Supply` is not frozen.
+//! After this function call the `Supply` object will not yet be set to 
+//! frozen, in order to give creators the ability to ammend it prior to 
+//! the primary sale taking place.
+//! 
+//! TODO: Consider adding a function `destroy_unregulated`?
 //! TODO: Consider adding a struct object Collection Proof
 //! TODO: Verify creator in function to add creator, and function to post verify
 //! TODO: Split field `is_mutable` to `is_mutable` and `frozen` such that 
@@ -15,21 +30,20 @@
 module nft_protocol::collection {
     use std::vector;
     use std::string::{Self, String};
-    use std::option::{Option};
+    use std::option::{Self, Option};
 
     use sui::event;
     use sui::object::{Self, UID, ID};
     use sui::tx_context::{TxContext};
+    use sui::transfer;
 
     use nft_protocol::tags::{Self, Tags};
     use nft_protocol::supply::{Self, Supply};
     use nft_protocol::supply_policy::{Self, SupplyPolicy};
 
-    /// An NFT `Collection` object with a generic `M`etadata and `C`ap.
-    /// NFT Collections can be instantiated with a `Cap` of type `Limited` or
-    /// `Unlimited`. An `Unlimited` collection not only does not have a supply
-    /// limit but also does not keep track of the amount of NFT `Data` objects
-    /// in existance at any given time.
+    const U64_MAX: u64 = 18446744073709551615;
+
+    /// An NFT `Collection` object with a generic `M`etadata.
     /// 
     /// The `Metadata` is a type exported by an upstream contract which is 
     /// used to store additional information about the NFT.
@@ -58,16 +72,23 @@ module nft_protocol::collection {
         /// the royalty enforcement standard
         royalty_fee_bps: u64,
         creators: vector<Creator>,
-        /// NFT Collections can be instantiated with a `Cap` of type `Limited`
-        ///  or `Unlimited`. An `Unlimited` collection not only does not have 
-        /// a supply limit but also does not keep track of the amount of 
-        /// NFT `Data` objects in existance at any given time.
-        /// TODO: Consider renaiming this field
-        /// TODO: Consider making this a separate object
-        supply_policy: SupplyPolicy,
+        /// ID of `MintAuthority` object
+        mint_authority: ID,
         /// The `Metadata` is a type exported by an upstream contract which is 
         /// used to store additional information about the NFT.
         metadata: M,
+    }
+
+    /// The `MintAuthority` object gives power to the owner to mint objects.
+    /// There is only one `MintAuthority` per `Collection`.
+    struct MintAuthority<phantom T> has key, store {
+        id: UID,
+        collection_id: ID,
+        // Defines supply policy which can be regulated or unregulated.
+        // A Collection with unregulated Supply policy is a collection that
+        // does not keep track of its current supply objects. This allows for the
+        // minting process to be parallelized.
+        supply_policy: SupplyPolicy,
     }
 
     /// Creator struct which holds the addresses of the creators of the NFT
@@ -98,23 +119,40 @@ module nft_protocol::collection {
         collection_id: ID,
     }
 
-    /// Initialises a Capped `Collection` object and returns it. A Capped
-    /// Collection is one which has a `Limited` object as its `Cap`.
-    /// `Limited` Collections have a fixed supply that can not be changed once
-    /// the `Cap` object is set to frozen. In this function call the `Limited`
-    /// object is not yet set to frozen, in order to give creators the ability
-    /// to ammend it prior to the primary sale taking place.
+
+    /// Initialises a `MintAuthority` and transfers it to `authority` and
+    /// initialized `Collection` object and returns it. The `MintAuthority`
+    /// object gives power to the owner to mint objects. There is only one
+    /// `MintAuthority` per `Collection`. The Mint Authority object contains a
+    /// `SupplyPolicy` which can be regulated or unregulated.
     /// 
-    /// Despite its name, `Limited` supplies can still have no maximum supply
-    /// constraint, if the field `supply.cap` is set to `option::none`. This
-    /// allows us to have a Collection that has no supply contraints whilst 
-    /// still being able to track how many NFT `Data` objects are currently
-    /// in existance. We can achieve this by setting the parameter
-    /// `max_supply` to `option::none`.
-    public fun mint_capped<T, M: store>(
+    /// A Collection with unregulated Supply policy is a collection that
+    /// does not keep track of its current supply objects. This allows for the
+    /// minting process to be parallelized.
+    /// 
+    /// To initialise a collection with a unregulated `SupplyPolicy`,
+    /// the parameter `max_supply` should be given as `0`. 
+    /// 
+    /// A Collection with regulated Supply policy is a collection that
+    /// keeps track of its current supply objects. This means that whilst the 
+    /// minting can be parallelized on the client side, on the blockchain side
+    /// nodes will have to lock the `MintAuthority` object in order to mutate
+    /// it sequentially. Regulated Supply allows for collections to have limited
+    /// or unlimited supply. The `MintAuthority` owner can modify the 
+    /// `max_supply` a posteriori, as long as the `Supply` is not frozen.
+    /// After this function call the `Supply` object will not yet be set to 
+    /// frozen, in order to give creators the ability to ammend it prior to 
+    /// the primary sale taking place.
+    /// 
+    /// To initialise a collection with regualred `SupplyPolicy`, the parameter
+    /// `max_supply` should be above `0`. To create an unlimited supply the
+    /// parameter `max_supply` should be equal to the biggest integer number
+    /// that can be stored in a u64, which is `18446744073709551615`.
+    public fun mint<T, M: store>(
         args: InitCollection,
-        max_supply: Option<u64>,
+        max_supply: u64,
         metadata: M,
+        authority: address,
         ctx: &mut TxContext,
     ): Collection<T, M> {
         let id = object::new(ctx);
@@ -124,6 +162,17 @@ module nft_protocol::collection {
                 collection_id: object::uid_to_inner(&id),
             }
         );
+
+        let mint_object_uid = object::new(ctx);
+        let mint_object_id = object::uid_to_inner(&mint_object_uid);
+
+        create_mint_authority<T>(
+            mint_object_uid,
+            object::uid_to_inner(&id),
+            max_supply,
+            authority,
+        );
+
 
         Collection {
             id,
@@ -135,55 +184,30 @@ module nft_protocol::collection {
             is_mutable: args.is_mutable,
             royalty_fee_bps: args.royalty_fee_bps,
             creators: vector::empty(),
-            supply_policy: supply_policy::create_limited(max_supply, false),
+            mint_authority: mint_object_id,
             metadata: metadata,
         }
     }
 
-    /// Initialises a Uncapped `Collection` object and returns it. An Uncapped
-    /// Collection is one which has a `Unlimited` object as its `Cap`.
-    /// `Unlimited` Collections do not have any supply contracints.
-    ///
-    /// Unlimited collections do not have a counter which incrementes when an
-    /// NFT `Data` object is minted, and thus they do not store the current
-    /// supply information. This means that the minting of NFT `Data` objects
-    /// can be done in parallel without mutating the `Collection` object.
-    public fun mint_uncapped<T, M: store>(
-        args: InitCollection,
-        metadata: M,
-        ctx: &mut TxContext,
-    ): Collection<T, M> {
-        let id = object::new(ctx);
-
-        event::emit(
-            MintEvent {
-                collection_id: object::uid_to_inner(&id),
-            }
-        );
-
-        Collection {
-            id,
-            name: args.name,
-            description: args.description,
-            symbol: args.symbol,
-            receiver: args.receiver,
-            tags: tags::from_vec_string(&mut args.tags),
-            is_mutable: args.is_mutable,
-            royalty_fee_bps: args.royalty_fee_bps,
-            creators: vector::empty(),
-            supply_policy: supply_policy::create_unlimited(),
-            metadata: metadata,
-        }
-    }
-
-    /// Burn a `Capped` Collection object and return the Metadata object
-    public fun burn_capped<T, M: store>(
+    
+    /// Burn a Collection with regulated supply object and
+    /// returns the Metadata object
+    public fun burn_regulated<T, M: store>(
         collection: Collection<T, M>,
+        mint: MintAuthority<T>,
     ): M {
         assert!(
-            supply::current(supply_policy::supply(&collection.supply_policy)) == 0,
+            supply::current(supply_policy::supply(&mint.supply_policy)) == 0,
             0
         );
+
+        let MintAuthority {
+            id,
+            collection_id: _,
+            supply_policy,
+        } = mint;
+
+        object::delete(id);
 
         event::emit(
             BurnEvent {
@@ -201,11 +225,11 @@ module nft_protocol::collection {
             is_mutable: _,
             royalty_fee_bps: _,
             creators: _,
-            supply_policy,
+            mint_authority: _,
             metadata,
         } = collection;
 
-        supply_policy::destroy_capped(supply_policy);
+        supply_policy::destroy_regulated(supply_policy);
 
         object::delete(id);
 
@@ -365,90 +389,81 @@ module nft_protocol::collection {
         }
     }
 
-    /// `Limited` collections can have a cap on the maximum supply, however 
-    /// the supply cap can also be `option::none()`. This function call
-    /// adds a value to the supply cap.
-    public entry fun cap_supply<T, M: store>(
-        collection: &mut Collection<T, M>,
-        value: u64
-    ) {
-        // Only modify if collection is mutable
-        assert!(collection.is_mutable == true, 0);
+    // /// Collections with regulated supply can have a cap on the maximum supply, however 
+    // /// the supply cap can also be `option::none()`. This function call
+    // /// adds a value to the supply cap.
+    // public entry fun cap_supply<T>(
+    //     mint: &mut MintAuthority<T>,
+    //     value: u64
+    // ) {
+    //     supply_policy::cap_supply(
+    //         &mut mint.supply_policy,
+    //         value
+    //     )
+    // }
 
-        supply::cap_supply(
-            supply_policy::supply_mut(&mut collection.supply_policy),
-            value
-        )
-    }
+    // /// Increases the `supply.max` by the `value` amount for 
+    // /// regulated collections. Invokes `supply::increase_cap()`
+    // public entry fun increase_max_supply<T>(
+    //     mint: &mut MintAuthority<T>,
+    //     value: u64,
+    // ) {
+    //     supply_policy::increase_max_supply(
+    //         &mut mint.supply_policy,
+    //         value,
+    //     );
+    // }
 
-    /// Increases the `supply.cap` by the `value` amount for 
-    /// `Limited` collections. Invokes `supply::increase_cap()`
-    public entry fun increase_supply_cap<T, M: store>(
-        collection: &mut Collection<T, M>,
-        value: u64
-    ) {
-        // Only modify if collection is mutable
-        assert!(collection.is_mutable == true, 0);
-
-        supply::increase_cap(
-            supply_policy::supply_mut(&mut collection.supply_policy),
-            value
-        )
-    }
-
-    /// Decreases the `supply.cap` by the `value` amount for 
-    /// `Limited` collections. This function call fails if one attempts
-    /// to decrease the supply cap to a value below the current supply.
-    /// Invokes `supply::decrease_cap()`
-    public entry fun decrease_supply_cap<T, M: store>(
-        collection: &mut Collection<T, M>,
-        value: u64
-    ) {
-        supply::decrease_cap(
-            supply_policy::supply_mut(&mut collection.supply_policy),
-            value
-        )
-    }
+    // /// Decreases the `supply.cap` by the `value` amount for 
+    // /// regulated collections. This function call fails if one attempts
+    // /// to decrease the supply cap to a value below the current supply.
+    // /// Invokes `supply::decrease_cap()`
+    // public entry fun decrease_max_supply<T>(
+    //     mint: &mut MintAuthority<T>,
+    //     value: u64
+    // ) {
+    //     supply_policy::decrease_max_supply(
+    //         &mut mint.supply_policy,
+    //         value
+    //     )
+    // }
 
     // === Supply Functions ===
 
-    /// Increase `supply.current` for `Limited`
-    public fun increase_supply<T, M: store>(
-        collection: &mut Collection<T, M>,
+    /// Increase `supply.current` for regulated collections
+    public fun increase_supply<T>(
+        mint: &mut MintAuthority<T>,
         value: u64
     ) {
-        // Only modify if collection is mutable
-        assert!(collection.is_mutable == true, 0);
-
-        supply::increase_supply(
-            supply_policy::supply_mut(&mut collection.supply_policy),
+        supply_policy::increase_supply(
+            &mut mint.supply_policy,
             value
         )
     }
 
-    public fun decrease_supply<T, M: store>(
-        collection: &mut Collection<T, M>,
+    public fun decrease_supply<T>(
+        mint: &mut MintAuthority<T>,
         value: u64
     ) {
-        supply::decrease_supply(
-            supply_policy::supply_mut(&mut collection.supply_policy),
+        supply_policy::decrease_supply(
+            &mut mint.supply_policy,
             value
         )
     }
 
-    public fun supply<T, M: store>(collection: &Collection<T, M>): &Supply {
-        supply_policy::supply(&collection.supply_policy)
+    public fun supply<T>(mint: &mut MintAuthority<T>): &Supply {
+        supply_policy::supply(&mint.supply_policy)
     }
 
-    public fun supply_cap<T, M: store>(collection: &Collection<T, M>): Option<u64> {
-        supply::cap(
-            supply_policy::supply(&collection.supply_policy)
+    public fun supply_cap<T>(mint: &mut MintAuthority<T>): Option<u64> {
+        supply::max(
+            supply_policy::supply(&mint.supply_policy)
         )
     }
 
-    public fun current_supply<T, M: store>(collection: &Collection<T, M>): u64 {
+    public fun current_supply<T>(mint: &mut MintAuthority<T>): u64 {
         supply::current(
-            supply_policy::supply(&collection.supply_policy)
+            supply_policy::supply(&mint.supply_policy)
         )
     }
 
@@ -525,20 +540,17 @@ module nft_protocol::collection {
     }
 
     /// Get an immutable reference to Collections's `cap`
-    public fun supply_policy<T, M: store>(
-        collection: &Collection<T, M>,
+    public fun supply_policy<T>(
+        mint: &MintAuthority<T>,
     ): &SupplyPolicy {
-        &collection.supply_policy
+        &mint.supply_policy
     }
 
     /// Get a mutable reference to Collections's `cap`
-    public fun cap_mut<T, M: store>(
-        collection: &mut Collection<T, M>,
+    public fun cap_mut<T>(
+        mint: &mut MintAuthority<T>,
     ): &mut SupplyPolicy {
-        // Only modify if collection is mutable
-        assert!(collection.is_mutable == true, 0);
-
-        &mut collection.supply_policy
+        &mut mint.supply_policy
     }
 
     /// Get an immutable reference to Collections's `Metadata`
@@ -558,7 +570,44 @@ module nft_protocol::collection {
         &mut collection.metadata
     }
 
+    public fun mint_collection_id<T>(
+        mint: &MintAuthority<T>,
+    ): ID {
+        mint.collection_id
+    }
+
     // === Private Functions ===
+
+    fun create_mint_authority<T>(
+        object_id: UID,
+        collection_id: ID,
+        max_supply: u64,
+        recipient: address,
+    ) {
+        if (max_supply == 0) {
+            let authority: MintAuthority<T> = MintAuthority {
+                id: object_id,
+                collection_id: collection_id,
+                supply_policy: supply_policy::create_unregulated(),
+            };
+
+            transfer::transfer(authority, recipient);
+        } else {
+            let max_supply_opt = option::none();
+
+            if (max_supply != U64_MAX) {
+                option::fill(&mut max_supply_opt, max_supply)
+            };
+
+            let authority: MintAuthority<T> = MintAuthority {
+                id: object_id,
+                collection_id: collection_id,
+                supply_policy: supply_policy::create_regulated(max_supply_opt, false),
+            };
+
+            transfer::transfer(authority, recipient);
+        }
+    }
 
     fun contains_address(
         v: &vector<Creator>, c_address: address

--- a/sources/examples/suimarines.move
+++ b/sources/examples/suimarines.move
@@ -4,10 +4,10 @@ module nft_protocol::suimarines {
 
     use std::vector;
     
-    use nft_protocol::collection::Collection;
-    use nft_protocol::std_collection::{Self, StdMeta};
-    use nft_protocol::slingshot::Slingshot;
+    use nft_protocol::collection::{MintAuthority};
     use nft_protocol::fixed_price::{Self, Market};
+    use nft_protocol::slingshot::Slingshot;
+    use nft_protocol::std_collection;
     use nft_protocol::unique_nft;
 
     struct SUIMARINES has drop {}
@@ -16,7 +16,7 @@ module nft_protocol::suimarines {
         // TODO: Consider using witness explicitly in function call
         let receiver = @0xA;
 
-        std_collection::mint_and_transfer<SUIMARINES>(
+        std_collection::mint<SUIMARINES>(
             b"Suimarines",
             b"A Unique NFT collection of Submarines on Sui",
             b"SUIM", // symbol
@@ -26,7 +26,7 @@ module nft_protocol::suimarines {
             100, // royalty_fee_bps
             false, // is_mutable
             b"Some extra data",
-            tx_context::sender(ctx), // recipient
+            tx_context::sender(ctx), // mint authority
             ctx,
         );
     }
@@ -54,19 +54,19 @@ module nft_protocol::suimarines {
         url: vector<u8>,
         attribute_keys: vector<vector<u8>>,
         attribute_values: vector<vector<u8>>,
-        collection: &mut Collection<SUIMARINES, StdMeta>,
+        mint_authority: &mut MintAuthority<SUIMARINES>,
         sale_index: u64,
         launchpad: &mut Slingshot<SUIMARINES, Market>,
         ctx: &mut TxContext,
     ) {
-        unique_nft::launchpad_mint_limited_collection_nft(
+        unique_nft::mint_regulated_nft(
             index,
             name,
             description,
             url,
             attribute_keys,
             attribute_values,
-            collection,
+            mint_authority,
             sale_index,
             launchpad,
             ctx,

--- a/sources/nft/nfts/collectibles.move
+++ b/sources/nft/nfts/collectibles.move
@@ -13,7 +13,7 @@ module nft_protocol::collectibles {
     use sui::tx_context::{TxContext};
     use sui::url::{Self, Url};
     
-    use nft_protocol::collection::{Self, Collection};
+    use nft_protocol::collection::{Self, Collection, MintAuthority};
     use nft_protocol::supply_policy;
     use nft_protocol::utils::{to_string_vector};
     use nft_protocol::supply::{Self, Supply};
@@ -58,13 +58,15 @@ module nft_protocol::collectibles {
 
     /// Mints loose NFT `Collectible` data and shares it.
     /// Invokes `mint_and_share_data()`.
-    /// Mints a Collectible data object for NFT(s) from a `Collection` of `Unlimited` supply.
-    /// The only way to mint the NFT for a collection is to give a reference to
-    /// [`UID`]. One is only allowed to mint `Nft`s for a given collection
-    /// if one is the collection owner, or if it is a shared collection.
+    /// 
+    /// Mints a Collectible data object for NFT(s) from an unregulated 
+    /// `Collection`.
+    /// The only way to mint the NFT data for a collection is to give a 
+    /// reference to [`UID`]. One is only allowed to mint `Nft`s for a 
+    /// given collection if one is the `MintAuthority` owner.
     /// 
     /// To be called by the Witness Module deployed by NFT creator.
-    public fun mint_unlimited_collection_nft_data<T, M: store>(
+    public fun mint_unregulated_nft_data<T>(
         index: u64,
         name: vector<u8>,
         description: vector<u8>,
@@ -72,12 +74,12 @@ module nft_protocol::collectibles {
         attribute_keys: vector<vector<u8>>,
         attribute_values: vector<vector<u8>>,
         max_supply: Option<u64>,
-        collection: &Collection<T, M>,
+        mint: &MintAuthority<T>,
         ctx: &mut TxContext,
     ) {
-        // Unlimited collections have an unregulated supply policy
+        // Assert that it has an unregulated supply policy
         assert!(
-            !supply_policy::regulated(collection::supply_policy(collection)), 0
+            !supply_policy::regulated(collection::supply_policy(mint)), 0
         );
 
         let args = mint_args(
@@ -92,20 +94,24 @@ module nft_protocol::collectibles {
 
         mint_and_share_data(
             args,
-            collection::id(collection),
+            collection::mint_collection_id(mint),
             ctx,
         );
     }
 
     /// Mints loose NFT `Collectible` data and shares it.
     /// Invokes `mint_and_share_data()`.
-    /// Mints a Collectible data object for NFT(s) from a `Collection` of `Limited` supply.
-    /// The only way to mint the NFT for a collection is to give a reference to
-    /// [`UID`]. One is only allowed to mint `Nft`s for a given collection
-    /// if one is the collection owner, or if it is a shared collection.
+    /// 
+    /// Mints a Collectible data object for NFT(s) from a regulated 
+    /// `Collection`.
+    /// The only way to mint the NFT data for a collection is to give a 
+    /// reference to [`UID`]. One is only allowed to mint `Nft`s for a 
+    /// given collection if one is the `MintAuthority` owner.
     /// 
     /// To be called by the Witness Module deployed by NFT creator.
-    public fun mint_limited_collection_nft_data<T, M: store>(
+    /// 
+    /// To be called by the Witness Module deployed by NFT creator.
+    public fun mint_regulated_nft_data<T>(
         index: u64,
         name: vector<u8>,
         description: vector<u8>,
@@ -113,12 +119,12 @@ module nft_protocol::collectibles {
         attribute_keys: vector<vector<u8>>,
         attribute_values: vector<vector<u8>>,
         max_supply: Option<u64>,
-        collection: &mut Collection<T, M>,
+        mint: &mut MintAuthority<T>,
         ctx: &mut TxContext,
     ) {
-        // Limited collections have a regulated supply policy
+        // Assert that it has a regulated supply policy
         assert!(
-            supply_policy::regulated(collection::supply_policy(collection)), 0
+            supply_policy::regulated(collection::supply_policy(mint)), 0
         );
 
         let args = mint_args(
@@ -131,11 +137,11 @@ module nft_protocol::collectibles {
             max_supply,
         );
 
-        collection::increase_supply(collection, 1);
+        collection::increase_supply(mint, 1);
 
         mint_and_share_data(
             args,
-            collection::id(collection),
+            collection::mint_collection_id(mint),
             ctx,
         );
     }
@@ -147,7 +153,7 @@ module nft_protocol::collectibles {
     /// To be called by Launchpad contract
     /// TODO: The flow here needs to be reconsidered
     public fun mint_nft<T, M: store>(
-        _collection: &Collection<T, M>,
+        _mint: &MintAuthority<T>,
         nft_data: &mut Collectible,
         recipient: address,
         ctx: &mut TxContext,
@@ -177,20 +183,21 @@ module nft_protocol::collectibles {
     /// In other words, the `supply.current` must be zero.
     public entry fun burn_limited_collection_nft_data<T, M: store>(
         nft_data: Collectible,
+        mint: &mut MintAuthority<T>,
         collection: &mut Collection<T, M>,
     ) {
-        // Limited collections have a regulated supply policy
+        // Assert that it has a regulated supply policy
         assert!(
-            supply_policy::regulated(collection::supply_policy(collection)), 0
+            supply_policy::regulated(collection::supply_policy(mint)), 0
         );
 
         assert!(
-            nft_data.collection_id == collection::id(collection), 0
+            nft_data.collection_id == collection::mint_collection_id(mint), 0
         );
 
         assert!(collection::is_mutable(collection), 0);
 
-        collection::decrease_supply(collection, 1);
+        collection::decrease_supply(mint, 1);
 
         let Collectible {
             id,
@@ -206,7 +213,7 @@ module nft_protocol::collectibles {
         event::emit(
             BurnDataEvent {
                 object_id: object::uid_to_inner(&id),
-                collection_id: collection::id(collection),
+                collection_id: collection::mint_collection_id(mint),
             }
         );
 
@@ -229,9 +236,9 @@ module nft_protocol::collectibles {
 
     // === Supply Functions ===
 
-    /// NFT `Collectible` data objects have an opt-in `supply.cap`.
+    /// NFT `Collectible` data objects have an opt-in `supply.max`.
     /// `Data` objects without supply will have `option::none()` in its value.
-    /// This Function call adds a value to the supply cap.
+    /// This Function call adds a value to the supply max.
     public entry fun cap_supply<T, M: store>(
         collection: &Collection<T, M>,
         nft_data: &mut Collectible,
@@ -245,7 +252,7 @@ module nft_protocol::collectibles {
         )
     }
 
-    /// Increases the `supply.cap` of the NFT `Collectible`
+    /// Increases the `supply.max` of the NFT `Collectible`
     /// by the `value` amount
     public entry fun increase_supply_cap<T, M: store>(
         collection: &Collection<T, M>,
@@ -260,7 +267,7 @@ module nft_protocol::collectibles {
         )
     }
 
-    /// Decreases the `supply.cap` of the NFT `Collectible`
+    /// Decreases the `supply.max` of the NFT `Collectible`
     /// by the `value` amount.
     /// This function call fails if one attempts to decrease the supply cap
     /// to a value below the current supply.

--- a/sources/supply/policy.move
+++ b/sources/supply/policy.move
@@ -1,12 +1,9 @@
-//! Module contaning two supply `Cap` types, namely `Limited` and `Unlimited`.
+//! Module contaning `SupplyPolicy` type.
 //! 
-//! `Limited` collections can have a cap on the maximum supply and keep track 
-//! of the current supply, whilst `Unlimited` collection have no supply 
+//! A `SupplyPolicy` can be regulated or unregulated. Regulated policies
+//! can have a ceiling on the maximum supply and keep track 
+//! of the current supply, whilst unregulated policies have no supply 
 //! constraints nor they keep track of the number of minted objects.
-//! 
-//! Despite the name, `Limited` Collections can be set to have indeterminate 
-//! supply cap, and if so, they only differ from Unlimited supply in that
-//! they keep track of the current supply.
 module nft_protocol::supply_policy {
     use std::option::{Self, Option};
     use nft_protocol::supply::{Self, Supply};
@@ -16,7 +13,7 @@ module nft_protocol::supply_policy {
         supply: Option<Supply>,
     }
 
-    public fun create_limited(
+    public fun create_regulated(
         max_supply: Option<u64>,
         frozen: bool,
     ): SupplyPolicy {
@@ -26,7 +23,7 @@ module nft_protocol::supply_policy {
         }
     }
 
-    public fun create_unlimited(
+    public fun create_unregulated(
     ): SupplyPolicy {
         SupplyPolicy {
             regulated: false,
@@ -48,8 +45,66 @@ module nft_protocol::supply_policy {
         option::borrow_mut(&mut policy.supply)
     }
 
-    public fun destroy_capped(policy: SupplyPolicy) {
-        // One can only destroy a SupplyPolicy that is not blind
+    public fun cap_supply(policy: &mut SupplyPolicy, value: u64) {
+        assert!(policy.regulated == true, 0);
+        supply::cap_supply(option::borrow_mut(&mut policy.supply), value);
+    }
+
+    /// Increases the `supply.max` by the `value` amount for 
+    /// regulated policies. Invokes `supply::increase_cap()`
+    public fun increase_max_supply(
+        policy: &mut SupplyPolicy,
+        value: u64,
+    ) {
+        assert!(!regulated(policy), 0);
+
+        supply::increase_cap(
+            supply_mut(policy),
+            value
+        )
+    }
+
+    /// Decreases the `supply.cap` by the `value` amount for 
+    /// regulated policies. This function call fails if one attempts
+    /// to decrease the supply cap to a value below the current supply.
+    /// Invokes `supply::decrease_cap()`
+    public fun decrease_max_supply(
+        policy: &mut SupplyPolicy,
+        value: u64
+    ) {
+        assert!(!regulated(policy), 0);
+
+        supply::decrease_cap(
+            supply_mut(policy),
+            value
+        )
+    }
+
+    /// Increase `supply.current` for regulated policies
+    public fun increase_supply(
+        policy: &mut SupplyPolicy,
+        value: u64
+    ) {
+        assert!(!regulated(policy), 0);
+
+        supply::increase_supply(
+            supply_mut(policy),
+            value
+        )
+    }
+
+    public fun decrease_supply(
+        policy: &mut SupplyPolicy,
+        value: u64
+    ) {
+        supply::decrease_supply(
+            supply_mut(policy),
+            value
+        )
+    }
+
+    public fun destroy_regulated(policy: SupplyPolicy) {
+        // One can only destroy a SupplyPolicy that is regulated
         assert!(policy.regulated == true, 0);
 
         assert!(supply::current(option::borrow(&policy.supply)) == 0, 0);

--- a/sources/supply/supply.move
+++ b/sources/supply/supply.move
@@ -3,14 +3,14 @@ module nft_protocol::supply {
 
     struct Supply has store {
         frozen: bool,
-        cap: Option<u64>,
+        max: Option<u64>,
         current: u64,
     }
 
     // === Supply <-> morphing and accessors  ===
-    
-    public fun cap(supply: &Supply): Option<u64> {
-        supply.cap
+
+    public fun max(supply: &Supply): Option<u64> {
+        supply.max
     }
 
     public fun current(supply: &Supply): u64 {
@@ -18,13 +18,13 @@ module nft_protocol::supply {
     }
 
     public fun cap_supply(supply: &mut Supply, value: u64) {
-        assert!(option::is_none(&supply.cap), 0);
-        option::fill(&mut supply.cap, value);
+        assert!(option::is_none(&supply.max), 0);
+        option::fill(&mut supply.max, value);
     }
 
     public fun increase_supply(supply: &mut Supply, value: u64) {
-        assert!(!option::is_none(&supply.cap), 0);
-        assert!(supply.current <= *option::borrow(&supply.cap), 0);
+        assert!(!option::is_none(&supply.max), 0);
+        assert!(supply.current <= *option::borrow(&supply.max), 0);
         supply.current = supply.current + value;
     }
 
@@ -34,32 +34,32 @@ module nft_protocol::supply {
     }
 
     public fun increase_cap(supply: &mut Supply, value: u64) {
-        assert!(!option::is_none(&supply.cap), 0);
+        assert!(!option::is_none(&supply.max), 0);
         assert!(supply.frozen == false, 0);
         
-        let cap = option::extract(&mut supply.cap);
-        option::fill(&mut supply.cap, cap + value);
+        let cap = option::extract(&mut supply.max);
+        option::fill(&mut supply.max, cap + value);
     }
 
     public fun decrease_cap(supply: &mut Supply, value: u64) {
-        assert!(!option::is_none(&supply.cap), 0);
+        assert!(!option::is_none(&supply.max), 0);
         assert!(supply.frozen == false, 0);
         
         // Decrease in supply cap cannot result in supply cap smaller
         // than current supply
-        assert!(*option::borrow(&supply.cap) - value > supply.current, 0);
+        assert!(*option::borrow(&supply.max) - value > supply.current, 0);
         
-        let cap = option::extract(&mut supply.cap);
-        option::fill(&mut supply.cap, cap + value);
+        let max = option::extract(&mut supply.max);
+        option::fill(&mut supply.max, max + value);
     }
 
     public fun destroy(supply: Supply) {
         // TODO: Confirm this is secure
         assert!(supply.current == 0, 0);
-        let Supply { frozen: _, cap: _, current: _ } = supply;
+        let Supply { frozen: _, max: _, current: _ } = supply;
     }
 
-    public fun new(cap: Option<u64>, frozen: bool): Supply {
-        Supply { frozen: frozen, cap: cap, current: 0 }
+    public fun new(max: Option<u64>, frozen: bool): Supply {
+        Supply { frozen: frozen, max: max, current: 0 }
     }
 }


### PR DESCRIPTION
- Collection is now shared object and has no supply policy responsability
- MintAuthority is object owned by NFT creators that controls the supply policy
- Added `mint_authority` field to Collection