### PR TITLE
Toggling Sale Status Permissions

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "NftProtocol"
-version = "0.6.0"
+version = "0.5.0"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "481dba3" }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-- Sui v0.10.0
+- Sui v0.12.1
 
 # Install
 

--- a/sources/launchpad/market/fixed_price.move
+++ b/sources/launchpad/market/fixed_price.move
@@ -245,18 +245,28 @@ module nft_protocol::fixed_price {
     // // === Modifier Functions ===
 
     /// Toggle the Slingshot's `live` to `true` therefore 
-    /// making the NFT sale live.
+    /// making the NFT sale live. Permissioned endpoint to be called by `admin`.
     public entry fun sale_on<T>(
         slingshot: &mut Slingshot<T, FixedPriceMarket>,
+        ctx: &mut TxContext
     ) {
+        assert!(
+            slingshot::admin(slingshot) == tx_context::sender(ctx),
+            err::wrong_launchpad_admin()
+        );
         slingshot::sale_on(slingshot);
     }
 
     /// Toggle the Slingshot's `live` to `false` therefore 
-    /// pausing or stopping the NFT sale.
+    /// pausing or stopping the NFT sale. Permissioned endpoint to be called by `admin`.
     public entry fun sale_off<T>(
         slingshot: &mut Slingshot<T, FixedPriceMarket>,
+        ctx: &mut TxContext
     ) {
+        assert!(
+            slingshot::admin(slingshot) == tx_context::sender(ctx),
+            err::wrong_launchpad_admin()
+        );
         slingshot::sale_off(slingshot);
     }
 


### PR DESCRIPTION
The toggling of the sale status of a launchpad should be exclusive to its admin and not accessible to any person.