### PR TITLE
Upgrading to Sui 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2022-11-03
+
+### Changed
+
+- Updated Sui dep to `0.14.0`
+- Since `transfer_to_object` was deprecated, we now use `dynamic_object_field`
+  with slingshot to associate embedded NFTs.
+
 ## [0.6.0] - 2022-10-26
 
-Added:
+### Added
+
 - Gutenberg: A rust templating engine to write Move NFT collection specific
   modules that top into our protocol.
 
-Changed:
+### Changed
 
 - Togling sale status permission via `fixed_price::sale_on` and`fized_price::sale_off` is now a permissioned action, that can only be done by the admin
 - Simplified `supply` module by removing changing field `max` from `Option<u64>` to `u64`
@@ -22,7 +31,7 @@ Changed:
 
 ## [0.5.0] - 2022-10-21
 
-Changed:
+### Changed
 
 - Updated `Sui` to version `0.12.1`
 - Moved the supply mint policy responsibility off the `Collection` object to a separate
@@ -32,12 +41,12 @@ Changed:
 - `Slingshot` module has entrypoints `claim_nft_embedded` and `claim_nt_loose`
 - `std_collection::mint_and_transfer` function now expected `u64` for field `max_supply` instead of `Option<u64>` to facilitate function call on the client side
 
-Added:
+### Added
 
 - `supply_policy` module with object `SupplyPolicy` to regulate NFT Collection supply
 - Error handling via `err` module
 
-Removed:
+### Removed
 
 - `cap` module with objects `Limited` and `Unlimited` that regulate the supply
   of NFT collections

--- a/Move.toml
+++ b/Move.toml
@@ -1,9 +1,9 @@
 [package]
 name = "NftProtocol"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "481dba3" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "devnet-0.14.0" }
 
 [addresses]
 nft_protocol = "0x0"

--- a/sources/launchpad/sale.move
+++ b/sources/launchpad/sale.move
@@ -18,7 +18,7 @@ module nft_protocol::sale {
 
     use nft_protocol::err;
 
-    struct Sale<phantom T, Market> has key, store{
+    struct Sale<phantom T, Market> has key, store {
         id: UID,
         tier_index: u64,
         whitelisted: bool,

--- a/sources/nft/nfts/unique_nft.move
+++ b/sources/nft/nfts/unique_nft.move
@@ -375,10 +375,7 @@ module nft_protocol::unique_nft {
 
         sale::add_nft<T, M>(sale, nft::id(&nft));
 
-        transfer::transfer_to_object(
-            nft,
-            launchpad,
-        );
+        slingshot::mint_nft_to(launchpad, nft);
     }
 
     fun burn_nft_<T>(


### PR DESCRIPTION
### Changed

- Updated Sui dep to `0.14.0`
- Since `transfer_to_object` was deprecated, we now use `dynamic_object_field`
  with slingshot to associate embedded NFTs.