### PR TITLE
Gutenberg integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "gumdrop"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +49,7 @@ name = "gutenberg"
 version = "0.1.0"
 dependencies = [
  "gumdrop",
+ "pretty_assertions",
  "serde_yaml",
  "strfmt",
  "thiserror",
@@ -59,6 +76,27 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -151,3 +189,31 @@ name = "unsafe-libyaml"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/gutenberg/Cargo.toml
+++ b/gutenberg/Cargo.toml
@@ -8,3 +8,6 @@ serde_yaml = "0.9"
 thiserror = "1.0"
 strfmt = "0.2"
 gumdrop = "0.8.1"
+
+[dev-dependencies]
+pretty_assertions = "1.3.0"

--- a/gutenberg/examples/collectibles.yaml
+++ b/gutenberg/examples/collectibles.yaml
@@ -1,4 +1,4 @@
-NftType: "Collectibles"
+NftType: "Collectible"
 
 Collection:
   name: "Suinamis"

--- a/gutenberg/src/lib.rs
+++ b/gutenberg/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod err;
+pub mod prelude;
+pub mod schema;
+pub mod types;

--- a/gutenberg/src/main.rs
+++ b/gutenberg/src/main.rs
@@ -1,11 +1,6 @@
-pub mod err;
-pub mod prelude;
-pub mod schema;
-pub mod types;
-
-use crate::err::*;
-use crate::prelude::*;
-use crate::schema::*;
+use gutenberg::err::*;
+use gutenberg::prelude::*;
+use gutenberg::schema::*;
 
 use gumdrop::Options;
 
@@ -28,7 +23,21 @@ fn main() -> Result<(), GutenError> {
 
     let schema = Schema::from_yaml(&yaml)?;
 
-    schema.write_move(opt.path)?;
+    let output = opt.path.unwrap_or_else(|| {
+        PathBuf::from_str(&format!(
+            "../sources/examples/{}.move",
+            &schema.module_name().to_string()
+        ))
+        .unwrap()
+    });
+
+    match output.parent() {
+        Some(p) => fs::create_dir_all(p)?,
+        None => {}
+    }
+
+    let mut f = File::create(output)?;
+    schema.write_move(&mut f)?;
 
     Ok(())
 }

--- a/gutenberg/tests/generate.rs
+++ b/gutenberg/tests/generate.rs
@@ -1,0 +1,35 @@
+//! Integration tests directly check the generated examples in the parent directory
+
+use gutenberg::schema::Schema;
+use std::fs::File;
+
+#[test]
+fn multi_sales() {
+    let config = File::open("./examples/multi_sales.yaml").unwrap();
+    let expected =
+        std::fs::read_to_string("../sources/examples/multi_sales.move")
+            .unwrap();
+
+    assert_equal(config, expected);
+}
+
+#[test]
+fn collectible() {
+    let config = File::open("./examples/collectibles.yaml").unwrap();
+    let expected =
+        std::fs::read_to_string("../sources/examples/collectibles.move")
+            .unwrap();
+
+    assert_equal(config, expected);
+}
+
+fn assert_equal(config: File, expected: String) {
+    let yaml: serde_yaml::Value = serde_yaml::from_reader(config).unwrap();
+    let schema = Schema::from_yaml(&yaml).unwrap();
+
+    let mut output = Vec::new();
+    schema.write_move(&mut output).unwrap();
+    let output = String::from_utf8(output).unwrap();
+
+    pretty_assertions::assert_eq!(output, expected);
+}

--- a/sources/examples/collectibles.move
+++ b/sources/examples/collectibles.move
@@ -1,0 +1,71 @@
+module nft_protocol::suinamis {
+    use std::vector;
+
+    use sui::tx_context::{Self, TxContext};
+    
+    use nft_protocol::collection::{MintAuthority};
+    use nft_protocol::fixed_price;
+    use nft_protocol::std_collection;
+    use nft_protocol::collectible;
+    
+
+    struct SUINAMIS has drop {}
+
+    fun init(witness: SUINAMIS, ctx: &mut TxContext) {
+        let tags: vector<vector<u8>> = vector::empty();
+        
+        vector::push_back(&mut tags, b"Art");
+        vector::push_back(&mut tags, b"PFP");
+
+        let collection_id = std_collection::mint<SUINAMIS>(
+            b"Suinamis",
+            b"A Unique NFT collection of Suinamis on Sui",
+            b"SUIN", // symbol
+            100, // max_supply
+            @0x6c86ac4a796204ea09a87b6130db0c38263c1890, // Royalty receiver
+            tags, // tags
+            100, // royalty_fee_bps
+            true, // is_mutable
+            b"Some extra data",
+            tx_context::sender(ctx), // mint authority
+            ctx,
+        );
+
+        let whitelisting = false;
+
+        let pricing = 1000;
+        
+        fixed_price::create_single_market(
+            witness,
+            tx_context::sender(ctx), // admin
+            collection_id,
+            @0x6c86ac4a796204ea09a87b6130db0c38263c1890,
+            false, // is_embedded
+            whitelisting, // whitelist
+            pricing, // price
+            ctx,
+        );
+    }
+
+    public entry fun mint_nft<T>(
+        name: vector<u8>,
+        description: vector<u8>,
+        url: vector<u8>,
+        attribute_keys: vector<vector<u8>>,
+        attribute_values: vector<vector<u8>>,
+        max_supply: u64,
+        mint: &mut MintAuthority<SUINAMIS>,
+        ctx: &mut TxContext,
+    ) {
+        collectible::mint_regulated_nft_data(
+            name,
+            description,
+            url,
+            attribute_keys,
+            attribute_values,
+            max_supply,
+            mint,
+            ctx,
+        );
+    }
+}

--- a/sources/examples/multi_sales.move
+++ b/sources/examples/multi_sales.move
@@ -1,0 +1,83 @@
+module nft_protocol::suimonsters {
+    use std::vector;
+
+    use sui::tx_context::{Self, TxContext};
+    
+    use nft_protocol::collection::{MintAuthority};
+    use nft_protocol::fixed_price::{Self, FixedPriceMarket};
+    use nft_protocol::std_collection;
+    use nft_protocol::unique_nft;
+    use nft_protocol::slingshot::Slingshot;
+
+    struct SUIMONSTERS has drop {}
+
+    fun init(witness: SUIMONSTERS, ctx: &mut TxContext) {
+        let tags: vector<vector<u8>> = vector::empty();
+        
+        vector::push_back(&mut tags, b"Art");
+        vector::push_back(&mut tags, b"PFP");
+
+        let collection_id = std_collection::mint<SUIMONSTERS>(
+            b"SuiMonsters",
+            b"A Unique NFT collection of SuiMonsters on Sui",
+            b"SUIMO", // symbol
+            100, // max_supply
+            @0x6c86ac4a796204ea09a87b6130db0c38263c1890, // Royalty receiver
+            tags, // tags
+            100, // royalty_fee_bps
+            true, // is_mutable
+            b"Some extra data",
+            tx_context::sender(ctx), // mint authority
+            ctx,
+        );
+
+        let whitelisting = vector::empty();
+        vector::push_back(&mut whitelisting, false);
+        vector::push_back(&mut whitelisting, true);
+        vector::push_back(&mut whitelisting, true);
+        vector::push_back(&mut whitelisting, true);
+
+
+        let pricing = vector::empty();
+        vector::push_back(&mut pricing, 1000);
+        vector::push_back(&mut pricing, 2000);
+        vector::push_back(&mut pricing, 3000);
+        vector::push_back(&mut pricing, 4000);
+
+        
+        fixed_price::create_multi_market(
+            witness,
+            tx_context::sender(ctx), // admin
+            collection_id,
+            @0x6c86ac4a796204ea09a87b6130db0c38263c1890,
+            true, // is_embedded
+            whitelisting, // whitelist
+            pricing, // price
+            ctx,
+        );
+    }
+
+    public entry fun mint_nft(
+        name: vector<u8>,
+        description: vector<u8>,
+        url: vector<u8>,
+        attribute_keys: vector<vector<u8>>,
+        attribute_values: vector<vector<u8>>,
+        mint_authority: &mut MintAuthority<SUIMONSTERS>,
+        sale_index: u64,
+        launchpad: &mut Slingshot<SUIMONSTERS, FixedPriceMarket>,
+        ctx: &mut TxContext,
+    ) {
+        unique_nft::mint_regulated_nft(
+            name,
+            description,
+            url,
+            attribute_keys,
+            attribute_values,
+            mint_authority,
+            sale_index,
+            launchpad,
+            ctx,
+        );
+    }
+}


### PR DESCRIPTION
Allows `Schema::write_move` to take a generic parameter, allowing us to write basic integration tests that check `gutenberg` generation. 

Would like to use this for testing generated auction code.