### PR TITLE
Serde derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ version = "0.1.0"
 dependencies = [
  "gumdrop",
  "pretty_assertions",
+ "serde",
  "serde_yaml",
  "strfmt",
  "thiserror",
@@ -127,6 +128,20 @@ name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_yaml"

--- a/gutenberg/Cargo.toml
+++ b/gutenberg/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "1.0"
 strfmt = "0.2"

--- a/gutenberg/src/err.rs
+++ b/gutenberg/src/err.rs
@@ -7,6 +7,8 @@ pub enum GutenError {
     MissingField,
     #[error("A field seems to have the wrong format")]
     WrongFormat,
+    #[error("Sale outlet parameters must have the same length")]
+    MismatchedOutletParams,
     #[error("Parsing error has occured")]
     SerdeYaml(serde_yaml::Error),
     #[error("An IO error has occured")]

--- a/gutenberg/src/main.rs
+++ b/gutenberg/src/main.rs
@@ -17,11 +17,8 @@ struct Opt {
 fn main() -> Result<(), GutenError> {
     let opt = Opt::parse_args_default_or_exit();
 
-    let f = std::fs::File::open(opt.config)?;
-
-    let yaml: serde_yaml::Value = serde_yaml::from_reader(f)?;
-
-    let schema = Schema::from_yaml(&yaml)?;
+    let f = std::fs::File::open("config.yaml")?;
+    let schema = serde_yaml::from_reader::<_, Schema>(f)?;
 
     let output = opt.path.unwrap_or_else(|| {
         PathBuf::from_str(&format!(

--- a/gutenberg/src/main.rs
+++ b/gutenberg/src/main.rs
@@ -17,7 +17,7 @@ struct Opt {
 fn main() -> Result<(), GutenError> {
     let opt = Opt::parse_args_default_or_exit();
 
-    let f = std::fs::File::open("config.yaml")?;
+    let f = std::fs::File::open(opt.config)?;
     let schema = serde_yaml::from_reader::<_, Schema>(f)?;
 
     let output = opt.path.unwrap_or_else(|| {

--- a/gutenberg/src/schema.rs
+++ b/gutenberg/src/schema.rs
@@ -178,10 +178,6 @@ impl Schema {
             MarketType::FixedPrice { prices, whitelists } => {
                 (prices.clone(), whitelists.clone())
             }
-            MarketType::Auction {
-                reserve_prices,
-                whitelists,
-            } => (reserve_prices.clone(), whitelists.clone()),
         }
     }
 

--- a/gutenberg/src/schema.rs
+++ b/gutenberg/src/schema.rs
@@ -86,7 +86,7 @@ impl Schema {
 
         let tags = self.write_tags();
 
-        let (mut prices, mut whitelists) = self.get_sale_outlets();
+        let (mut prices, mut whitelists) = self.get_sale_outlets()?;
 
         let sale_type = if prices.len() == 1 {
             "create_single_market"
@@ -173,10 +173,16 @@ impl Schema {
             .into_boxed_str()
     }
 
-    pub fn get_sale_outlets(&self) -> (Vec<u64>, Vec<bool>) {
+    pub fn get_sale_outlets(
+        &self,
+    ) -> Result<(Vec<u64>, Vec<bool>), GutenError> {
         match &self.launchpad.market_type {
             MarketType::FixedPrice { prices, whitelists } => {
-                (prices.clone(), whitelists.clone())
+                if prices.len() != whitelists.len() {
+                    return Err(GutenError::MismatchedOutletParams);
+                }
+
+                Ok((prices.clone(), whitelists.clone()))
             }
         }
     }

--- a/gutenberg/src/types.rs
+++ b/gutenberg/src/types.rs
@@ -146,17 +146,12 @@ pub enum MarketType {
         prices: Vec<u64>,
         whitelists: Vec<bool>,
     },
-    Auction {
-        reserve_prices: Vec<u64>,
-        whitelists: Vec<bool>,
-    },
 }
 
 impl MarketType {
     pub fn market_type(&self) -> Box<str> {
         match self {
             MarketType::FixedPrice { .. } => "FixedPriceMarket",
-            MarketType::Auction { .. } => "AuctionMarket",
         }
         .into()
     }
@@ -164,7 +159,6 @@ impl MarketType {
     pub fn market_module(&self) -> Box<str> {
         match self {
             MarketType::FixedPrice { .. } => "fixed_price",
-            MarketType::Auction { .. } => "auction",
         }
         .into()
     }

--- a/gutenberg/tests/generate.rs
+++ b/gutenberg/tests/generate.rs
@@ -1,14 +1,27 @@
 //! Integration tests directly check the generated examples in the parent directory
 
 use gutenberg::schema::Schema;
-use std::fs::File;
+use std::fs::{self, File};
+
+/// Check that all examples have correct schema
+#[test]
+fn example_schema() {
+    fs::read_dir("./examples")
+        .unwrap()
+        .map(Result::unwrap)
+        .map(|dir| {
+            let config = File::open(dir.path()).unwrap();
+            dbg!(&config);
+            assert_schema(config);
+        })
+        .collect::<()>()
+}
 
 #[test]
 fn multi_sales() {
     let config = File::open("./examples/multi_sales.yaml").unwrap();
     let expected =
-        std::fs::read_to_string("../sources/examples/multi_sales.move")
-            .unwrap();
+        fs::read_to_string("../sources/examples/multi_sales.move").unwrap();
 
     assert_equal(config, expected);
 }
@@ -17,15 +30,19 @@ fn multi_sales() {
 fn collectible() {
     let config = File::open("./examples/collectibles.yaml").unwrap();
     let expected =
-        std::fs::read_to_string("../sources/examples/collectibles.move")
-            .unwrap();
+        fs::read_to_string("../sources/examples/collectibles.move").unwrap();
 
     assert_equal(config, expected);
 }
 
+/// Asserts that the config file has correct schema
+fn assert_schema(config: File) -> Schema {
+    serde_yaml::from_reader::<_, Schema>(config).unwrap()
+}
+
+/// Asserts that the generated file matches the expected output
 fn assert_equal(config: File, expected: String) {
-    let yaml: serde_yaml::Value = serde_yaml::from_reader(config).unwrap();
-    let schema = Schema::from_yaml(&yaml).unwrap();
+    let schema = assert_schema(config);
 
     let mut output = Vec::new();
     schema.write_move(&mut output).unwrap();

--- a/gutenberg/tests/generate.rs
+++ b/gutenberg/tests/generate.rs
@@ -11,7 +11,6 @@ fn example_schema() {
         .map(Result::unwrap)
         .map(|dir| {
             let config = File::open(dir.path()).unwrap();
-            dbg!(&config);
             assert_schema(config);
         })
         .collect::<()>()
@@ -42,10 +41,8 @@ fn assert_schema(config: File) -> Schema {
 
 /// Asserts that the generated file matches the expected output
 fn assert_equal(config: File, expected: String) {
-    let schema = assert_schema(config);
-
     let mut output = Vec::new();
-    schema.write_move(&mut output).unwrap();
+    assert_schema(config).write_move(&mut output).unwrap();
     let output = String::from_utf8(output).unwrap();
 
     pretty_assertions::assert_eq!(output, expected);

--- a/sources/examples/multi_sales.move
+++ b/sources/examples/multi_sales.move
@@ -43,6 +43,7 @@ module nft_protocol::suimonsters {
         vector::push_back(&mut pricing, 2000);
         vector::push_back(&mut pricing, 3000);
         vector::push_back(&mut pricing, 4000);
+        vector::push_back(&mut pricing, 5000);
 
         
         fixed_price::create_multi_market(

--- a/sources/examples/multi_sales.move
+++ b/sources/examples/multi_sales.move
@@ -43,7 +43,6 @@ module nft_protocol::suimonsters {
         vector::push_back(&mut pricing, 2000);
         vector::push_back(&mut pricing, 3000);
         vector::push_back(&mut pricing, 4000);
-        vector::push_back(&mut pricing, 5000);
 
         
         fixed_price::create_multi_market(


### PR DESCRIPTION
- Uses `serde-derive` to automatically deserialize `Schema`.
- Validates that schema for all our examples is correct.

Rebased on top of https://github.com/Origin-Byte/nft-protocol/pull/60