### PR TITLE
Cleanup errors and prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,6 @@ dependencies = [
  "gumdrop",
  "pretty_assertions",
  "serde",
- "serde_path_to_error",
  "serde_yaml",
  "strfmt",
  "thiserror",
@@ -142,15 +141,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "gumdrop",
  "pretty_assertions",
  "serde",
+ "serde_path_to_error",
  "serde_yaml",
  "strfmt",
  "thiserror",
@@ -141,6 +142,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/gutenberg/Cargo.toml
+++ b/gutenberg/Cargo.toml
@@ -10,7 +10,6 @@ gumdrop = "0.8"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-serde_path_to_error = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/gutenberg/Cargo.toml
+++ b/gutenberg/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
 thiserror = "1.0"
 strfmt = "0.2"
-gumdrop = "0.8.1"
+gumdrop = "0.8"
+
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"
+serde_path_to_error = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/gutenberg/src/err.rs
+++ b/gutenberg/src/err.rs
@@ -1,51 +1,11 @@
-use std::fmt::Display;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum GutenError {
-    #[error("A field seems to be missing")]
-    MissingField,
-    #[error("A field seems to have the wrong format")]
-    WrongFormat,
     #[error("Sale outlet parameters must have the same length")]
     MismatchedOutletParams,
     #[error("Parsing error has occured")]
-    SerdeYaml(serde_yaml::Error),
+    SerdeYaml(#[from] serde_yaml::Error),
     #[error("An IO error has occured")]
-    IoError(std::io::Error),
-    #[error("An unexpected error has occurred")]
-    UnexpectedErrror,
-}
-
-pub fn miss(msg: impl Display) -> GutenError {
-    println!("[MissingField] {}", msg);
-
-    GutenError::MissingField
-}
-
-pub fn format<'a>(msg: impl Display + PartialEq<&'a str>) -> GutenError {
-    if (msg == "prices") | (msg == "whitelists") {
-        let example = if msg == "prices" { "100" } else { "true" };
-
-        println!(
-            "[WrongFormat] Consider representing the field `{}` as an array \
-            (e.g. [{}]) instead of a number (e.g. {})",
-            msg, example, example,
-        );
-    } else {
-        println!("[WrongFormat] The field `{}` has the wrong format", msg);
-    }
-
-    GutenError::WrongFormat
-}
-
-impl From<serde_yaml::Error> for GutenError {
-    fn from(e: serde_yaml::Error) -> Self {
-        GutenError::SerdeYaml(e)
-    }
-}
-impl From<std::io::Error> for GutenError {
-    fn from(e: std::io::Error) -> Self {
-        GutenError::IoError(e)
-    }
+    IoError(#[from] std::io::Error),
 }

--- a/gutenberg/src/main.rs
+++ b/gutenberg/src/main.rs
@@ -20,10 +20,13 @@ fn main() -> Result<(), GutenError> {
 
     let f = fs::File::open(opt.config)?;
 
-    let de = serde_yaml::Deserializer::from_reader(f);
-    let schema: Schema = match serde_path_to_error::deserialize(de) {
+    let schema: Schema = match serde_yaml::from_reader(f) {
         Ok(schema) => schema,
-        Err(err) => todo!(),
+        Err(err) => {
+            eprintln!("Gutenberg could not generate smart contract due to");
+            eprintln!("{}", err);
+            std::process::exit(2);
+        }
     };
 
     let output = opt.path.unwrap_or_else(|| {

--- a/gutenberg/src/main.rs
+++ b/gutenberg/src/main.rs
@@ -19,7 +19,12 @@ fn main() -> Result<(), GutenError> {
     let opt = Opt::parse_args_default_or_exit();
 
     let f = fs::File::open(opt.config)?;
-    let schema = serde_yaml::from_reader::<_, Schema>(f)?;
+
+    let de = serde_yaml::Deserializer::from_reader(f);
+    let schema: Schema = match serde_path_to_error::deserialize(de) {
+        Ok(schema) => schema,
+        Err(err) => todo!(),
+    };
 
     let output = opt.path.unwrap_or_else(|| {
         PathBuf::from(&format!(

--- a/gutenberg/src/main.rs
+++ b/gutenberg/src/main.rs
@@ -1,8 +1,9 @@
-use gutenberg::err::*;
 use gutenberg::prelude::*;
-use gutenberg::schema::*;
 
 use gumdrop::Options;
+
+use std::fs;
+use std::path::PathBuf;
 
 #[derive(Debug, Options)]
 struct Opt {
@@ -17,22 +18,21 @@ struct Opt {
 fn main() -> Result<(), GutenError> {
     let opt = Opt::parse_args_default_or_exit();
 
-    let f = std::fs::File::open(opt.config)?;
+    let f = fs::File::open(opt.config)?;
     let schema = serde_yaml::from_reader::<_, Schema>(f)?;
 
     let output = opt.path.unwrap_or_else(|| {
-        PathBuf::from_str(&format!(
-            "../sources/{}.move",
+        PathBuf::from(&format!(
+            "../examples/{}.move",
             &schema.module_name().to_string()
         ))
-        .unwrap()
     });
 
     if let Some(p) = output.parent() {
         fs::create_dir_all(p)?;
     }
 
-    let mut f = File::create(output)?;
+    let mut f = fs::File::create(output)?;
     if let Err(err) = schema.write_move(&mut f) {
         eprintln!("{err}");
     }

--- a/gutenberg/src/prelude.rs
+++ b/gutenberg/src/prelude.rs
@@ -1,13 +1,3 @@
-extern crate strfmt;
-
-pub use crate::err::{self, GutenError};
+pub use crate::err::GutenError;
+pub use crate::schema::*;
 pub use crate::types::*;
-
-pub use serde_yaml::Value;
-pub use std::collections::HashMap;
-pub use std::fs;
-pub use std::fs::File;
-pub use std::io::prelude::*;
-pub use std::path::PathBuf;
-pub use std::str::FromStr;
-pub use strfmt::strfmt;

--- a/gutenberg/src/schema.rs
+++ b/gutenberg/src/schema.rs
@@ -2,7 +2,8 @@
 //! struct `Schema`, acting as an intermediate data structure, to write
 //! the associated Move module and dump into a default or custom folder defined
 //! by the caller.
-use crate::prelude::*;
+use crate::err::GutenError;
+use crate::types::{MarketType, NftType};
 
 use serde::Deserialize;
 

--- a/gutenberg/src/schema.rs
+++ b/gutenberg/src/schema.rs
@@ -5,7 +5,10 @@
 use crate::prelude::*;
 
 use serde::Deserialize;
+
+use std::collections::HashMap;
 use std::fmt::Write;
+use std::fs;
 
 /// Struct that acts as an intermediate data structure representing the yaml
 /// configuration of the NFT collection.
@@ -136,7 +139,7 @@ impl Schema {
             .collect();
 
         output.write_all(
-            strfmt(&fmt, &vars)
+            strfmt::strfmt(&fmt, &vars)
                 // This is expected not to result in an error since we
                 // have explicitly handled all error cases
                 .unwrap_or_else(|_| {

--- a/gutenberg/src/types.rs
+++ b/gutenberg/src/types.rs
@@ -131,7 +131,7 @@ pub enum SalesType {
     MultiMarket,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(tag = "market_type", rename_all = "snake_case")]
 pub enum MarketType {
     FixedPrice {


### PR DESCRIPTION
- Cleans up `GutenError` cases
- Cleans up `prelude`, which should be used to export crate types not std types
