### PR TITLE
Tests: Safe module

### DIFF
--- a/sources/safe/safe.move
+++ b/sources/safe/safe.move
@@ -38,8 +38,8 @@ module nft_protocol::safe {
         /// How many transfer caps are there for this version.
         transfer_cap_counter: u64,
         /// Only one `TransferCap` of the latest version can exist.
-        /// An exlusively listed NFT cannot have its `TransferCap` revoked.
-        is_exlusively_listed: bool,
+        /// An exclusively listed NFT cannot have its `TransferCap` revoked.
+        is_exclusively_listed: bool,
     }
 
     /// Whoever owns this object can perform some admin actions against the
@@ -63,7 +63,7 @@ module nft_protocol::safe {
         ///
         /// If an NFT is listed exclusively, it cannot be revoked without
         /// burning the `TransferCap` first.
-        is_exlusive: bool,
+        is_exclusive: bool,
     }
 
     struct DepositEvent has copy, drop {
@@ -103,7 +103,7 @@ module nft_protocol::safe {
 
         let safe_id = object::id(safe);
         let ref = vec_map::get_mut(&mut safe.refs, &nft);
-        assert_not_exlusively_listed(ref);
+        assert_not_exclusively_listed_internal(ref);
         ref.transfer_cap_counter = ref.transfer_cap_counter + 1;
         if (ref.transfer_cap_counter == 1) {
             ref.version = new_id(ctx);
@@ -111,7 +111,7 @@ module nft_protocol::safe {
 
         TransferCap {
             id: object::new(ctx),
-            is_exlusive: false,
+            is_exclusive: false,
             nft: nft,
             safe: safe_id,
             version: ref.version,
@@ -121,7 +121,7 @@ module nft_protocol::safe {
     /// Creates an irrevocable and exclusive transfer cap.
     ///
     /// Useful for trading contracts which cannot claim an NFT atomically.
-    public fun create_exlusive_transfer_cap(
+    public fun create_exclusive_transfer_cap(
         nft: ID,
         owner_cap: &OwnerCap,
         safe: &mut Safe,
@@ -132,14 +132,15 @@ module nft_protocol::safe {
 
         let safe_id = object::id(safe);
         let ref = vec_map::get_mut(&mut safe.refs, &nft);
-        assert_not_exlusively_listed(ref);
+        assert_not_exclusively_listed_internal(ref);
 
         ref.transfer_cap_counter = 1;
+        ref.is_exclusively_listed = true;
         ref.version = new_id(ctx);
 
         TransferCap {
             id: object::new(ctx),
-            is_exlusive: true,
+            is_exclusive: true,
             nft: nft,
             safe: safe_id,
             version: ref.version,
@@ -147,7 +148,7 @@ module nft_protocol::safe {
     }
 
     /// The owner can restrict deposits into the `Safe` from other users.
-    public entry fun toggle_accepts_any_deposit<T, D: store>(
+    public entry fun toggle_accepts_any_deposit(
         owner_cap: &OwnerCap,
         safe: &mut Safe,
     ) {
@@ -160,13 +161,13 @@ module nft_protocol::safe {
     ///
     /// However, if the flag `Safe::accepts_any_deposit` is set to true, then
     /// that takes precedence.
-    public entry fun toggle_deposits_of_collection<T, D: store>(
+    public entry fun toggle_deposits_of_collection<C>(
         owner_cap: &OwnerCap,
         safe: &mut Safe,
     ) {
         assert_owner_cap(owner_cap, safe);
 
-        let col_type = type_name::get<T>();
+        let col_type = type_name::get<C>();
         if (vec_set::contains(&safe.collections_with_enabled_deposits, &col_type)) {
             vec_set::remove(&mut safe.collections_with_enabled_deposits, &col_type);
         } else {
@@ -202,7 +203,7 @@ module nft_protocol::safe {
 
     /// Use a transfer cap to get an NFT out of the `Safe`.
     ///
-    /// If the NFT is not exlusively listed, it can happen that the transfer
+    /// If the NFT is not exclusively listed, it can happen that the transfer
     /// cap is no longer valid. The NFT could've been traded or the trading cap
     /// revoked.
     public fun transfer_nft_to_recipient<T, Auth: drop>(
@@ -221,7 +222,7 @@ module nft_protocol::safe {
     /// to the target `Safe`. The recipient address should match the owner of
     /// the target `Safe`.
     ///
-    /// If the NFT is not exlusively listed, it can happen that the transfer
+    /// If the NFT is not exclusively listed, it can happen that the transfer
     /// cap is no longer valid. The NFT could've been traded or the trading cap
     /// revoked.
     public fun transfer_nft_to_safe<T, Auth: drop>(
@@ -239,7 +240,7 @@ module nft_protocol::safe {
         deposit_nft(nft, target, ctx);
     }
 
-    /// Destroys given transfer cap. This is mainly useful for exlusively listed
+    /// Destroys given transfer cap. This is mainly useful for exclusively listed
     /// NFTs.
     public entry fun burn_transfer_cap(
         transfer_cap: TransferCap,
@@ -249,7 +250,7 @@ module nft_protocol::safe {
 
         let TransferCap {
             id,
-            is_exlusive: _,
+            is_exclusive: _,
             nft,
             safe: _,
             version,
@@ -260,7 +261,7 @@ module nft_protocol::safe {
         if (ref.version == version) {
             ref.transfer_cap_counter = ref.transfer_cap_counter - 1;
             if (ref.transfer_cap_counter == 0) {
-                ref.is_exlusively_listed = false;
+                ref.is_exclusively_listed = false;
             };
         }
     }
@@ -268,7 +269,7 @@ module nft_protocol::safe {
     /// Changes the transfer ref version, thereby invalidating all existing
     /// `TransferCap` objects.
     ///
-    /// Can happen only if the NFT is not listed exlusively.
+    /// Can happen only if the NFT is not listed exclusively.
     public entry fun delist_nft(
         nft: ID,
         owner_cap: &OwnerCap,
@@ -279,7 +280,7 @@ module nft_protocol::safe {
         assert_contains_nft(&nft, safe);
 
         let ref = vec_map::get_mut(&mut safe.refs, &nft);
-        assert_not_exlusively_listed(ref);
+        assert_not_exclusively_listed_internal(ref);
 
         ref.version = new_id(ctx);
         ref.transfer_cap_counter = 0;
@@ -319,7 +320,7 @@ module nft_protocol::safe {
         vec_map::insert(&mut safe.refs, nft_id, NftRef {
             version: new_id(ctx),
             transfer_cap_counter: 0,
-            is_exlusively_listed: false,
+            is_exclusively_listed: false,
         });
 
         dof::add(&mut safe.id, nft_id, nft);
@@ -357,7 +358,7 @@ module nft_protocol::safe {
             safe: _,
             nft: _,
             version: _,
-            is_exlusive: _,
+            is_exclusive: _,
         } = transfer_cap;
         object::delete(id);
 
@@ -365,6 +366,10 @@ module nft_protocol::safe {
     }
 
     // === Getters ===
+
+    public fun has_nft<C>(nft: ID, safe: &Safe): bool {
+        dof::exists_with_type<ID, NFT<C>>(&safe.id, nft)
+    }
 
     public fun owner_cap_safe(cap: &OwnerCap): ID {
         cap.safe
@@ -383,8 +388,8 @@ module nft_protocol::safe {
     public fun transfer_cap_version(cap: &TransferCap): ID {
         cap.version
     }
-    public fun transfer_cap_is_exlusive(cap: &TransferCap): bool {
-        cap.is_exlusive
+    public fun transfer_cap_is_exclusive(cap: &TransferCap): bool {
+        cap.is_exclusive
     }
 
     // === Assertions ===
@@ -407,8 +412,8 @@ module nft_protocol::safe {
         );
     }
 
-    public fun assert_not_exlusively_listed(ref: &NftRef) {
-        assert!(!ref.is_exlusively_listed, err::nft_exlusively_listed());
+    public fun assert_not_exclusively_listed(cap: &TransferCap) {
+        assert!(!cap.is_exclusive, err::nft_exclusively_listed());
     }
 
     public fun assert_version_match(ref: &NftRef, cap: &TransferCap) {
@@ -426,5 +431,9 @@ module nft_protocol::safe {
 
     public fun assert_id(safe: &Safe, id: ID) {
         assert!(object::id(safe) == id, err::safe_id_mismatch());
+    }
+
+    fun assert_not_exclusively_listed_internal(ref: &NftRef) {
+        assert!(!ref.is_exclusively_listed, err::nft_exclusively_listed());
     }
 }

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -141,7 +141,7 @@ module nft_protocol::err {
         return Prefix + 401
     }
 
-    public fun nft_exlusively_listed(): u64 {
+    public fun nft_exclusively_listed(): u64 {
         return Prefix + 402
     }
 

--- a/tests/safe.move
+++ b/tests/safe.move
@@ -1,0 +1,804 @@
+#[test_only]
+module nft_protocol::test_safe {
+    use nft_protocol::collection::{Self, Collection};
+    use nft_protocol::nft::{Self, NFT};
+    use nft_protocol::safe::{Self, Safe, OwnerCap};
+    use nft_protocol::transfer_whitelist::{Self, Whitelist};
+    use std::vector;
+    use sui::object;
+    use sui::test_scenario::{Self, Scenario, ctx};
+    use sui::transfer::transfer;
+
+    struct Foo has drop {}
+
+    struct Witness has drop {}
+
+    const USER: address = @0xA1C04;
+
+    #[test]
+    fun it_creates_safe() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+        let owner_cap_safe_id = safe::owner_cap_safe(&owner_cap);
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        assert!(owner_cap_safe_id == object::id(&safe), 0);
+        safe::assert_id(&safe, owner_cap_safe_id);
+        safe::assert_owner_cap(&owner_cap, &safe);
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370406)]
+    fun it_fails_if_safe_id_mismatches() {
+        let scenario = test_scenario::begin(USER);
+
+        safe::create_for_sender(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        let id = object::new(ctx(&mut scenario));
+        safe::assert_id(&safe, object::uid_to_inner(&id));
+
+        object::delete(id);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_create_for_sender() {
+        let scenario = test_scenario::begin(USER);
+
+        safe::create_for_sender(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        let owner_cap: OwnerCap = test_scenario::take_from_sender(&scenario);
+        safe::assert_owner_cap(&owner_cap, &safe);
+
+        test_scenario::return_shared(safe);
+        test_scenario::return_to_sender(&scenario, owner_cap);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_deposits_nft() {
+        let scenario = test_scenario::begin(USER);
+
+        safe::create_for_sender(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+        assert!(safe::has_nft<Foo>(nft_id, &safe), 0);
+
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370405)]
+    fun it_cannot_deposit_nft_if_deposits_off() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::toggle_accepts_any_deposit(&owner_cap, &mut safe);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_can_deposit_whitelisted_collection() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::toggle_accepts_any_deposit(&owner_cap, &mut safe);
+        safe::toggle_deposits_of_collection<Foo>(&owner_cap, &mut safe);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+        assert!(safe::has_nft<Foo>(nft_id, &safe), 0);
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370405)]
+    fun it_toggles_collection_whitelisting_for_deposits() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::toggle_accepts_any_deposit(&owner_cap, &mut safe);
+        safe::toggle_deposits_of_collection<Foo>(&owner_cap, &mut safe);
+        safe::toggle_deposits_of_collection<Foo>(&owner_cap, &mut safe);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_creates_and_burns_transfer_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        safe::assert_transfer_cap_of_safe(&transfer_cap, &safe);
+        safe::assert_nft_of_transfer_cap(&nft_id, &transfer_cap);
+        assert!(!safe::transfer_cap_is_exclusive(&transfer_cap), 0);
+        safe::assert_not_exclusively_listed(&transfer_cap);
+
+        safe::burn_transfer_cap(transfer_cap, &mut safe);
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370401)]
+    fun it_cannot_create_transfer_cap_if_nft_not_present() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let transfer_cap = safe::create_transfer_cap(
+            object::id(&safe),
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+
+        transfer(transfer_cap, USER);
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_withdraws_nft_with_transfer_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        safe::assert_transfer_cap_of_safe(&transfer_cap, &safe);
+        safe::assert_nft_of_transfer_cap(&nft_id, &transfer_cap);
+
+        let wl = dummy_whitelist(&mut scenario);
+        safe::transfer_nft_to_recipient<Foo, Witness>(
+            transfer_cap, USER, Witness {}, &wl, &mut safe,
+        );
+        assert!(!safe::has_nft<Foo>(nft_id, &safe), 0);
+        test_scenario::next_tx(&mut scenario, USER);
+        let nft = test_scenario::take_from_sender<NFT<Foo>>(&scenario);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+        assert!(safe::has_nft<Foo>(nft_id, &safe), 0);
+
+        transfer(wl, USER);
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_creates_and_burns_exclusive_transfer_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_exclusive_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        safe::assert_transfer_cap_of_safe(&transfer_cap, &safe);
+        safe::assert_nft_of_transfer_cap(&nft_id, &transfer_cap);
+
+        safe::burn_transfer_cap(transfer_cap, &mut safe);
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_withdraws_nft_with_exclusive_transfer_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_exclusive_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        safe::assert_transfer_cap_of_safe(&transfer_cap, &safe);
+        safe::assert_nft_of_transfer_cap(&nft_id, &transfer_cap);
+        assert!(safe::transfer_cap_is_exclusive(&transfer_cap), 0);
+
+        let wl = dummy_whitelist(&mut scenario);
+        safe::transfer_nft_to_recipient<Foo, Witness>(
+            transfer_cap, USER, Witness {}, &wl, &mut safe,
+        );
+        assert!(!safe::has_nft<Foo>(nft_id, &safe), 0);
+        test_scenario::next_tx(&mut scenario, USER);
+        let nft = test_scenario::take_from_sender<NFT<Foo>>(&scenario);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+        assert!(safe::has_nft<Foo>(nft_id, &safe), 0);
+
+        transfer(wl, USER);
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_delists_transfer_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        let v1 = safe::transfer_cap_version(&transfer_cap);
+        safe::delist_nft(nft_id, &owner_cap, &mut safe, ctx(&mut scenario));
+        let transfer_cap2 = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        let v2 = safe::transfer_cap_version(&transfer_cap2);
+        assert!(v1 != v2, 0);
+        let transfer_cap3 = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        let v3 = safe::transfer_cap_version(&transfer_cap3);
+        assert!(v2 == v3, 0);
+        safe::delist_nft(nft_id, &owner_cap, &mut safe, ctx(&mut scenario));
+        let transfer_cap4 = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        let v4 = safe::transfer_cap_version(&transfer_cap4);
+        assert!(v3 != v4, 0);
+
+        safe::burn_transfer_cap(transfer_cap, &mut safe);
+        safe::burn_transfer_cap(transfer_cap2, &mut safe);
+        safe::burn_transfer_cap(transfer_cap3, &mut safe);
+        safe::burn_transfer_cap(transfer_cap4, &mut safe);
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370404)]
+    fun it_cannot_withdraw_nft_with_expired_transfer_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+
+        safe::delist_nft(nft_id, &owner_cap, &mut safe, ctx(&mut scenario));
+
+        let wl = dummy_whitelist(&mut scenario);
+        safe::transfer_nft_to_recipient<Foo, Witness>(
+            transfer_cap, USER, Witness {}, &wl, &mut safe,
+        );
+
+        transfer(wl, USER);
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_deposits_priviledged() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::toggle_accepts_any_deposit(&owner_cap, &mut safe);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        safe::deposit_nft_priviledged<Foo>(
+            nft,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_transfers_nft_to_another_safe() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap1 = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe1: Safe = test_scenario::take_shared(&scenario);
+
+        let owner_cap2 = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe2: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe1,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_exclusive_transfer_cap(
+            nft_id,
+            &owner_cap1,
+            &mut safe1,
+            ctx(&mut scenario),
+        );
+
+        let wl = dummy_whitelist(&mut scenario);
+        safe::transfer_nft_to_safe<Foo, Witness>(
+            transfer_cap,
+            USER,
+            Witness {},
+            &wl,
+            &mut safe1,
+            &mut safe2,
+            ctx(&mut scenario),
+        );
+        assert!(!safe::has_nft<Foo>(nft_id, &safe1), 0);
+        assert!(safe::has_nft<Foo>(nft_id, &safe2), 0);
+
+        transfer(wl, USER);
+        transfer(owner_cap1, USER);
+        transfer(owner_cap2, USER);
+        test_scenario::return_shared(safe1);
+        test_scenario::return_shared(safe2);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370402)]
+    fun it_cannot_create_transfer_cap_if_already_exclusively_listed() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap1 = safe::create_exclusive_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+        let transfer_cap2 = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(owner_cap, USER);
+        transfer(transfer_cap1, USER);
+        transfer(transfer_cap2, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370404)]
+    fun it_invalidates_prev_transfer_cap_if_exclusively_listed() {
+        let scenario = test_scenario::begin(USER);
+
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap1 = safe::create_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+        let transfer_cap2 = safe::create_exclusive_transfer_cap(
+            nft_id,
+            &owner_cap,
+            &mut safe,
+            ctx(&mut scenario)
+        );
+
+        let wl = dummy_whitelist(&mut scenario);
+        safe::transfer_nft_to_recipient<Foo, Witness>(
+            transfer_cap1, USER, Witness {}, &wl, &mut safe,
+        );
+        assert!(!safe::has_nft<Foo>(nft_id, &safe), 0);
+        test_scenario::next_tx(&mut scenario, USER);
+
+        transfer(owner_cap, USER);
+        transfer(wl, USER);
+        transfer(transfer_cap2, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370400)]
+    fun it_fails_create_transfer_cap_on_wrong_owner_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_transfer_cap(
+            nft_id,
+            &wrong_owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(transfer_cap, USER);
+        transfer(right_owner_cap, USER);
+        transfer(wrong_owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370400)]
+    fun it_fails_create_exclusive_transfer_cap_on_wrong_owner_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft<Foo>(
+            nft,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        let transfer_cap = safe::create_exclusive_transfer_cap(
+            nft_id,
+            &wrong_owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(transfer_cap, USER);
+        transfer(right_owner_cap, USER);
+        transfer(wrong_owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370400)]
+    fun it_fails_toggle_accepts_any_deposit_on_wrong_owner_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        safe::toggle_accepts_any_deposit(&wrong_owner_cap, &mut safe);
+
+        transfer(right_owner_cap, USER);
+        transfer(wrong_owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370400)]
+    fun it_fails_toggle_deposits_of_collection_on_wrong_owner_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        safe::toggle_deposits_of_collection<Foo>(&wrong_owner_cap, &mut safe);
+
+        transfer(right_owner_cap, USER);
+        transfer(wrong_owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370400)]
+    fun it_fails_deposit_nft_priviledged_on_wrong_owner_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        safe::deposit_nft_priviledged<Foo>(
+            nft,
+            &wrong_owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        transfer(right_owner_cap, USER);
+        transfer(wrong_owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370400)]
+    fun it_fails_delist_nft_on_wrong_owner_cap() {
+        let scenario = test_scenario::begin(USER);
+
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
+        test_scenario::next_tx(&mut scenario, USER);
+        let safe: Safe = test_scenario::take_shared(&scenario);
+
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
+
+        let nft = nft::new<Foo>(ctx(&mut scenario));
+        let nft_id = object::id(&nft);
+        safe::deposit_nft_priviledged<Foo>(
+            nft,
+            &right_owner_cap,
+            &mut safe,
+            ctx(&mut scenario),
+        );
+
+        safe::delist_nft(nft_id, &wrong_owner_cap, &mut safe, ctx(&mut scenario));
+
+        transfer(right_owner_cap, USER);
+        transfer(wrong_owner_cap, USER);
+        test_scenario::return_shared(safe);
+        test_scenario::end(scenario);
+    }
+
+    fun dummy_whitelist(scenario: &mut Scenario): Whitelist {
+        collection::mint<Foo>(
+            b"foo",
+            b"foo",
+            b"foo",
+            1,
+            USER,
+            vector::empty(),
+            0,
+            true,
+            USER,
+            ctx(scenario),
+        );
+        test_scenario::next_tx(scenario, USER);
+
+        let col: Collection<Foo> = test_scenario::take_shared(scenario);
+        collection::add_creator(&mut col, USER, 0);
+
+        let wl = transfer_whitelist::create(Witness {}, ctx(scenario));
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(scenario),
+        );
+        test_scenario::return_shared(col);
+
+        wl
+    }
+}


### PR DESCRIPTION
```
aldrin@porkbrain:~/Code/nft-protocol(tests/safe)$ sui move coverage summary
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000::err
>>> % Module coverage: 18.60
Module 0000000000000000000000000000000000000000::utils
>>> % Module coverage: 75.86
Module 0000000000000000000000000000000000000000::tags
>>> % Module coverage: 31.25
Module 0000000000000000000000000000000000000000::supply
>>> % Module coverage: 3.21
Module 0000000000000000000000000000000000000000::supply_policy
>>> % Module coverage: 5.00
Module 0000000000000000000000000000000000000000::domain
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::collection
>>> % Module coverage: 34.98
Module 0000000000000000000000000000000000000000::transfer_whitelist
>>> % Module coverage: 29.08
Module 0000000000000000000000000000000000000000::nft
>>> % Module coverage: 47.54
Module 0000000000000000000000000000000000000000::safe
>>> % Module coverage: 96.07
Module 0000000000000000000000000000000000000000::royalties
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::bidding
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::sale
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::slingshot
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::whitelist
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::dutch_auction
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::fixed_price
>>> % Module coverage: 0.00
+-------------------------+
| % Move Coverage: 27.03  |
+-------------------------+
```