### PR TITLE
Tests: trading whitelist

### DIFF
--- a/examples/whitelisting/free_for_all.move
+++ b/examples/whitelisting/free_for_all.move
@@ -1,0 +1,87 @@
+#[test_only]
+module nft_protocol::example_free_for_all {
+    //! A whitelist which permits any collection to add itself and any authority
+    //! to use it to transfer.
+    //!
+    //! Basically any collection which adds itself to this whitelist is saying:
+    //! we're ok with anyone transferring NFTs.
+
+    use nft_protocol::collection::{Self, Collection};
+    use nft_protocol::transfer_whitelist::{Self, Whitelist};
+    use sui::transfer::share_object;
+    use sui::tx_context::TxContext;
+
+    struct Witness has drop {}
+
+    fun init(ctx: &mut TxContext) {
+        init_(ctx)
+    }
+    fun init_(ctx: &mut TxContext) {
+        share_object(transfer_whitelist::create(Witness {}, ctx));
+    }
+
+    /// Only the creator is allowed to insert their collection.
+    ///
+    /// However, any creator can insert their collection into simple whitelist.
+    public entry fun insert_collection<T>(
+        collection: &Collection<T>,
+        list: &mut Whitelist,
+        ctx: &mut TxContext,
+    ) {
+        transfer_whitelist::insert_collection(
+            Witness {},
+            collection,
+            list,
+            ctx,
+        );
+    }
+
+    // --- Tests ---
+
+    use sui::test_scenario::{Self, Scenario, ctx};
+    use std::vector;
+
+    const USER: address = @0xA1C04;
+
+    #[test]
+    fun it_inserts_collection() {
+        let scenario = test_scenario::begin(USER);
+
+        init_(ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, USER);
+
+        let wl: Whitelist = test_scenario::take_shared(&scenario);
+
+        let col = dummy_collection(&mut scenario);
+
+        insert_collection(&col, &mut wl, ctx(&mut scenario));
+
+        test_scenario::return_shared(wl);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    struct Foo has drop {}
+    fun dummy_collection(scenario: &mut Scenario): Collection<Foo> {
+        collection::mint<Foo>(
+            b"foo",
+            b"foo",
+            b"foo",
+            1,
+            USER,
+            vector::empty(),
+            0,
+            true,
+            USER,
+            ctx(scenario),
+        );
+        test_scenario::next_tx(scenario, USER);
+
+        let col = test_scenario::take_shared(scenario);
+        collection::add_creator(&mut col, USER, 0);
+
+        col
+    }
+
+}

--- a/examples/whitelisting/free_for_all.move
+++ b/examples/whitelisting/free_for_all.move
@@ -39,7 +39,6 @@ module nft_protocol::example_free_for_all {
     // --- Tests ---
 
     use sui::test_scenario::{Self, Scenario, ctx};
-    use std::vector;
 
     const USER: address = @0xA1C04;
 
@@ -64,24 +63,6 @@ module nft_protocol::example_free_for_all {
 
     struct Foo has drop {}
     fun dummy_collection(scenario: &mut Scenario): Collection<Foo> {
-        collection::mint<Foo>(
-            b"foo",
-            b"foo",
-            b"foo",
-            1,
-            USER,
-            vector::empty(),
-            0,
-            true,
-            USER,
-            ctx(scenario),
-        );
-        test_scenario::next_tx(scenario, USER);
-
-        let col = test_scenario::take_shared(scenario);
-        collection::add_creator(&mut col, USER, 0);
-
-        col
+        collection::dummy_collection(USER, scenario)
     }
-
 }

--- a/sources/collection/collection.move
+++ b/sources/collection/collection.move
@@ -599,4 +599,30 @@ module nft_protocol::collection {
             }
         }
     }
+
+    // === Test only helpers ===
+
+    #[test_only]
+    public fun dummy_collection<T>(
+        creator: address,
+        scenario: &mut sui::test_scenario::Scenario,
+    ): Collection<T> {
+        sui::test_scenario::next_tx(scenario, creator);
+        share(create<T>(
+            b"foo",
+            1,
+            creator,
+            vector::empty(),
+            0,
+            true,
+            creator,
+            sui::test_scenario::ctx(scenario),
+        ));
+        sui::test_scenario::next_tx(scenario, creator);
+        let col = sui::test_scenario::take_shared(scenario);
+
+        add_creator(&mut col, creator, 0);
+
+        col
+    }
 }

--- a/sources/collection/collection.move
+++ b/sources/collection/collection.move
@@ -574,9 +574,7 @@ module nft_protocol::collection {
         share(create<T>(
             b"foo",
             1,
-            creator,
             vector::empty(),
-            0,
             true,
             creator,
             sui::test_scenario::ctx(scenario),

--- a/sources/safe/transfer_whitelist.move
+++ b/sources/safe/transfer_whitelist.move
@@ -141,14 +141,16 @@ module nft_protocol::transfer_whitelist {
         _authority_witness: Auth,
         whitelist: &Whitelist,
     ): bool {
+        let applies_to_collection =
+            vec_set::contains(&whitelist.collections, &type_name::get<C>());
+
         if (option::is_none(&whitelist.authorities)) {
-            return true
+            return applies_to_collection
         };
 
         let e = option::borrow(&whitelist.authorities);
 
-        vec_set::contains(e, &type_name::get<Auth>()) &&
-            vec_set::contains(&whitelist.collections, &type_name::get<C>())
+        applies_to_collection && vec_set::contains(e, &type_name::get<Auth>())
     }
 
     fun assert_is_creator<T>(

--- a/tests/transfer_whitelist.move
+++ b/tests/transfer_whitelist.move
@@ -2,7 +2,6 @@
 module nft_protocol::test_transfer_whitelist {
     use nft_protocol::collection::{Self, Collection};
     use nft_protocol::transfer_whitelist;
-    use std::vector;
     use sui::transfer::transfer;
     use sui::test_scenario::{Self, Scenario, ctx};
 
@@ -320,25 +319,6 @@ module nft_protocol::test_transfer_whitelist {
     }
 
     fun dummy_collection<T>(scenario: &mut Scenario): Collection<T> {
-        test_scenario::next_tx(scenario, CREATOR);
-
-        collection::mint<T>(
-            b"a",
-            b"a",
-            b"a",
-            1,
-            CREATOR,
-            vector::empty(),
-            0,
-            true,
-            CREATOR,
-            ctx(scenario),
-        );
-        test_scenario::next_tx(scenario, CREATOR);
-
-        let col: Collection<T> = test_scenario::take_shared(scenario);
-        collection::add_creator(&mut col, CREATOR, 0);
-
-        col
+        collection::dummy_collection(CREATOR, scenario)
     }
 }

--- a/tests/transfer_whitelist.move
+++ b/tests/transfer_whitelist.move
@@ -1,0 +1,344 @@
+#[test_only]
+module nft_protocol::test_transfer_whitelist {
+    use nft_protocol::collection::{Self, Collection};
+    use nft_protocol::transfer_whitelist;
+    use std::vector;
+    use sui::transfer::transfer;
+    use sui::test_scenario::{Self, Scenario, ctx};
+
+    struct Witness has drop {}
+    struct Witness2 has drop {}
+
+    struct Foo has drop {}
+    struct Bar has drop {}
+
+    const ADMIN: address = @0xA1C04;
+    const CREATOR: address = @0xA1C05;
+
+    #[test]
+    fun it_allows_collection_to_remove_itself() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        assert!(transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_whitelist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+
+        transfer_whitelist::remove_itself(&col, &mut wl, ctx(&mut scenario));
+
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370501)]
+    fun it_fails_to_remove_collection_if_not_creator() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+
+        transfer_whitelist::remove_itself(&col, &mut wl, ctx(&mut scenario));
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370501)]
+    fun it_fails_to_insert_collection_if_not_creator() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370502)]
+    fun it_fails_to_insert_collection_if_witness_mismatches() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness2 {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370502)]
+    fun it_fails_remove_collection_as_admin_if_witness_mismatches() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer_whitelist::remove_collection<Witness2, Foo>(Witness2 {}, &mut wl);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_removes_collection_as_admin() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col1 = dummy_collection<Foo>(&mut scenario);
+        let col2 = dummy_collection<Bar>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col1,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col2,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        assert!(transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(transfer_whitelist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+
+        transfer_whitelist::remove_collection<Witness, Foo>(Witness {}, &mut wl);
+
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(transfer_whitelist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col1,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer_whitelist::clear_collections(Witness {}, &mut wl);
+
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_whitelist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col1);
+        test_scenario::return_shared(col2);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_inserts_authority() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer_whitelist::insert_authority<Witness, Witness2>(Witness {}, &mut wl);
+
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(transfer_whitelist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+
+        transfer_whitelist::insert_authority<Witness, Witness>(Witness {}, &mut wl);
+
+        assert!(transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(transfer_whitelist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+
+        assert!(!transfer_whitelist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_whitelist::can_be_transferred<Bar, Witness2>(Witness2 {}, &wl), 0);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_removes_authority() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer_whitelist::insert_authority<Witness, Witness2>(Witness {}, &mut wl);
+
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(transfer_whitelist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+
+        transfer_whitelist::remove_authority<Witness, Witness2>(Witness {}, &mut wl);
+
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_whitelist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370502)]
+    fun it_fails_to_insert_authority_if_witness_mismatches() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        transfer_whitelist::insert_authority<Witness2, Witness2>(Witness2 {}, &mut wl);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370502)]
+    fun it_fails_to_remove_authority_if_witness_mismatches() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        transfer_whitelist::insert_authority<Witness, Witness2>(Witness {}, &mut wl);
+        transfer_whitelist::remove_authority<Witness2, Witness2>(Witness2 {}, &mut wl);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370502)]
+    fun it_fails_to_clear_collections_if_witness_mismatches() {
+        let scenario = test_scenario::begin(ADMIN);
+
+        let col = dummy_collection<Foo>(&mut scenario);
+
+        test_scenario::next_tx(&mut scenario, ADMIN);
+        let wl = transfer_whitelist::create(Witness {}, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+        transfer_whitelist::insert_collection(
+            Witness {},
+            &col,
+            &mut wl,
+            ctx(&mut scenario),
+        );
+
+        transfer_whitelist::clear_collections(Witness2 {}, &mut wl);
+
+        transfer(wl, ADMIN);
+        test_scenario::return_shared(col);
+        test_scenario::end(scenario);
+    }
+
+    fun dummy_collection<T>(scenario: &mut Scenario): Collection<T> {
+        test_scenario::next_tx(scenario, CREATOR);
+
+        collection::mint<T>(
+            b"a",
+            b"a",
+            b"a",
+            1,
+            CREATOR,
+            vector::empty(),
+            0,
+            true,
+            CREATOR,
+            ctx(scenario),
+        );
+        test_scenario::next_tx(scenario, CREATOR);
+
+        let col: Collection<T> = test_scenario::take_shared(scenario);
+        collection::add_creator(&mut col, CREATOR, 0);
+
+        col
+    }
+}


### PR DESCRIPTION
```
Test result: OK. Total tests: 41; passed: 41; failed: 0
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000::err
>>> % Module coverage: 23.26
Module 0000000000000000000000000000000000000000::utils
>>> % Module coverage: 75.86
Module 0000000000000000000000000000000000000000::tags
>>> % Module coverage: 31.25
Module 0000000000000000000000000000000000000000::supply
>>> % Module coverage: 3.21
Module 0000000000000000000000000000000000000000::supply_policy
>>> % Module coverage: 5.00
Module 0000000000000000000000000000000000000000::domain
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::collection
>>> % Module coverage: 37.34
Module 0000000000000000000000000000000000000000::transfer_whitelist
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000::nft
>>> % Module coverage: 47.54
Module 0000000000000000000000000000000000000000::safe
>>> % Module coverage: 96.07
Module 0000000000000000000000000000000000000000::royalties
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::bidding
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::sale
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::slingshot
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::whitelist
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::dutch_auction
>>> % Module coverage: 0.00
Module 0000000000000000000000000000000000000000::fixed_price
>>> % Module coverage: 0.00
+-------------------------+
| % Move Coverage: 30.65  |
+-------------------------+
```