### PR TITLE
Feature: Permissionless royalty domain

### DIFF
--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -54,12 +54,12 @@ module nft_protocol::suimarines {
             string::utf8(b"SUIM")
         );
 
-        royalty::add_royalty_domain(&mut collection, ctx);
+        let royalty = royalty::new(ctx);
         royalty::add_proportional_royalty(
-            &mut collection,
+            &mut royalty,
             nft_protocol::royalty_strategy_bps::new(100),
-            ctx,
         );
+        royalty::add_royalty_domain(&mut collection, royalty);
 
         let tags = tags::empty(ctx);
         tags::add_tag(&mut tags, tags::art());
@@ -75,11 +75,11 @@ module nft_protocol::suimarines {
     ) {
         let b = royalties::balance_mut(Witness {}, payment);
 
-        let domain = royalty::royalty_domain_mut(collection);
+        let domain = royalty::royalty_domain(collection);
         let royalty_owed =
             royalty::calculate_proportional_royalty(domain, balance::value(b));
 
-        royalty::transfer_royalties(domain, b, royalty_owed);
+        royalty::collect_royalty(collection, b, royalty_owed);
         royalties::transfer_remaining_to_beneficiary(Witness {}, payment, ctx);
     }
 

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -60,6 +60,7 @@ module nft_protocol::suitraders {
         collection::share<SUITRADERS>(collection);
     }
 
+    /// Calculates and transfers royalties to the `RoyaltyDomain`
     public entry fun collect_royalty<FT>(
         payment: &mut TradePayment<SUITRADERS, FT>,
         collection: &mut Collection<SUITRADERS>,
@@ -67,11 +68,11 @@ module nft_protocol::suitraders {
     ) {
         let b = royalties::balance_mut(Witness {}, payment);
 
-        let domain = royalty::royalty_domain_mut(collection);
+        let domain = royalty::royalty_domain(collection);
         let royalty_owed =
             royalty::calculate_proportional_royalty(domain, balance::value(b));
 
-        royalty::transfer_royalties(domain, b, royalty_owed);
+        royalty::collect_royalty(collection, b, royalty_owed);
         royalties::transfer_remaining_to_beneficiary(Witness {}, payment, ctx);
     }
 

--- a/sources/standards/attribution.move
+++ b/sources/standards/attribution.move
@@ -155,6 +155,8 @@ module nft_protocol::attribution {
             beneficiary.share_of_royalty_bps + creator.share_of_royalty_bps;
     }
 
+    /// Distributes content of `aggregate` balance among the creators defined
+    /// in the `AttributionDomain`
     public fun distribute_royalties<FT>(
         attributions: &AttributionDomain,
         aggregate: &mut Balance<FT>,

--- a/sources/standards/royalties/royalty.move
+++ b/sources/standards/royalties/royalty.move
@@ -40,19 +40,10 @@ module nft_protocol::royalty {
     /// === Royalties ===
 
     /// Add proportional royalty policy
-    ///
-    /// Requires that `AttributionDomain` is defined and sender is a creator
-    public fun add_proportional_royalty<C>(
-        nft: &mut Collection<C>,
+    public fun add_proportional_royalty(
+        domain: &mut RoyaltyDomain,
         strategy: BpsRoyaltyStrategy,
-        ctx: &mut TxContext,
     ) {
-        attribution::assert_collection_has_creator(
-            nft, tx_context::sender(ctx)
-        );
-
-        let domain = collection::borrow_domain_mut<C, RoyaltyDomain, Witness>(Witness {}, nft);
-
         bag::add(
             &mut domain.strategies,
             utils::marker<BpsRoyaltyStrategy>(),
@@ -61,19 +52,10 @@ module nft_protocol::royalty {
     }
 
     /// Add constant royalty policy
-    ///
-    /// Requires that `AttributionDomain` is defined and sender is a creator
-    public fun add_constant_royalty<C>(
-        nft: &mut Collection<C>,
+    public fun add_constant_royalty(
+        domain: &mut RoyaltyDomain,
         strategy: ConstantRoyaltyStrategy,
-        ctx: &mut TxContext,
     ) {
-        attribution::assert_collection_has_creator(
-            nft, tx_context::sender(ctx)
-        );
-
-        let domain = collection::borrow_domain_mut<C, RoyaltyDomain, Witness>(Witness {}, nft);
-
         bag::add(
             &mut domain.strategies,
             utils::marker<ConstantRoyaltyStrategy>(),
@@ -82,18 +64,9 @@ module nft_protocol::royalty {
     }
 
     /// Remove proportional royalty policy
-    ///
-    /// Requires that `AttributionDomain` is defined and sender is a creator
-    public fun remove_proportional_royalty<C>(
-        nft: &mut Collection<C>,
-        ctx: &mut TxContext,
+    public fun remove_proportional_royalty(
+        domain: &mut RoyaltyDomain,
     ) {
-        attribution::assert_collection_has_creator(
-            nft, tx_context::sender(ctx)
-        );
-
-        let domain = collection::borrow_domain_mut<C, RoyaltyDomain, Witness>(Witness {}, nft);
-
         let _: BpsRoyaltyStrategy = bag::remove(
             &mut domain.strategies,
             utils::marker<BpsRoyaltyStrategy>(),
@@ -101,18 +74,9 @@ module nft_protocol::royalty {
     }
 
     /// Remove constant royalty policy
-    ///
-    /// Requires that `AttributionDomain` is defined and sender is a creator
-    public fun remove_constant_royalty<C>(
-        nft: &mut Collection<C>,
-        ctx: &mut TxContext,
+    public fun remove_constant_royalty(
+        domain: &mut RoyaltyDomain,
     ) {
-        attribution::assert_collection_has_creator(
-            nft, tx_context::sender(ctx)
-        );
-
-        let domain = collection::borrow_domain_mut<C, RoyaltyDomain, Witness>(Witness {}, nft);
-
         let _: ConstantRoyaltyStrategy = bag::remove(
             &mut domain.strategies,
             utils::marker<ConstantRoyaltyStrategy>(),
@@ -164,25 +128,37 @@ module nft_protocol::royalty {
 
     /// === Utils ===
 
-    public fun transfer_royalties<FT>(
-        domain: &mut RoyaltyDomain,
+    struct Witness has drop {}
+
+    /// Collects an `amount` of tokens from the provided balance into the
+    /// aggregate balance of the `RoyaltyDomain` registered on the `Collection`
+    ///
+    /// Requires that a `RoyaltyDomain` is registered on the collection
+    public fun collect_royalty<C, FT>(
+        collection: &mut Collection<C>,
         source: &mut Balance<FT>,
         amount: u64,
     ) {
+        // Bypass creator check as anyone should be able to transfer royalties
+        // to the collection.
+        let domain: &mut RoyaltyDomain =
+            collection::borrow_domain_mut(Witness {}, collection);
+        let aggregations = &mut domain.aggregations;
+
         let b = balance::split(source, amount);
 
         if (!bag::contains_with_type<Marker<Balance<FT>>, Balance<FT>>(
-            &domain.aggregations, utils::marker<Balance<FT>>()
+            aggregations, utils::marker<Balance<FT>>()
         )) {
             bag::add(
-                &mut domain.aggregations,
+                aggregations,
                 utils::marker<Balance<FT>>(),
                 balance::zero<FT>(),
             );
         };
 
         let aggregate = bag::borrow_mut(
-            &mut domain.aggregations,
+            aggregations,
             utils::marker<Balance<FT>>()
         );
 
@@ -191,36 +167,46 @@ module nft_protocol::royalty {
 
     /// === Interoperability ===
 
-    struct Witness has drop {}
-
+    /// Get reference to `RoyaltyDomain`
     public fun royalty_domain<C>(
         collection: &Collection<C>,
     ): &RoyaltyDomain {
         collection::borrow_domain(collection)
     }
 
+    /// Get mutable reference to `RoyaltyDomain`
+    ///
+    /// Requires that `AttributionDomain` is defined and sender is a creator
     public fun royalty_domain_mut<C>(
         collection: &mut Collection<C>,
+        ctx: &mut TxContext,
     ): &mut RoyaltyDomain {
+        attribution::assert_collection_has_creator(
+            collection, tx_context::sender(ctx)
+        );
+
         collection::borrow_domain_mut(Witness {}, collection)
     }
 
+    /// Registers `RoyaltyDomain` on the given `Collection`
     public fun add_royalty_domain<C>(
         collection: &mut Collection<C>,
-        ctx: &mut TxContext,
+        domain: RoyaltyDomain,
     ) {
-        collection::add_domain(collection, new(ctx));
+        collection::add_domain(collection, domain);
     }
 
+    /// Distribute aggregated royalties among creators
     public entry fun distribute_royalties<C, FT>(
         collection: &mut Collection<C>,
         ctx: &mut TxContext,
     ) {
         let attributions = *attribution::attribution_domain(collection);
 
-        let royalty: &mut RoyaltyDomain = royalty_domain_mut(collection);
+        let domain: &mut RoyaltyDomain =
+            collection::borrow_domain_mut(Witness {}, collection);
         let aggregate: &mut Balance<FT> = bag::borrow_mut(
-            &mut royalty.aggregations,
+            &mut domain.aggregations,
             utils::marker<Balance<FT>>(),
         );
 


### PR DESCRIPTION
Makes `RoyaltyDomain` more ergonomic to work around by only asserting that `ctx` is a creator when obtaining a mutable reference from `Collection`.

Rebased on top of https://github.com/Origin-Byte/nft-protocol/pull/127