### PR TITLE
Fix: Rename NFT to Nft

### DIFF
--- a/sources/launchpad/launchpad.move
+++ b/sources/launchpad/launchpad.move
@@ -14,7 +14,7 @@ module nft_protocol::launchpad {
     use sui::object_bag::{Self, ObjectBag};
 
     use nft_protocol::err;
-    use nft_protocol::nft::NFT;
+    use nft_protocol::nft::Nft;
     use nft_protocol::proceeds::{Self, Proceeds};
     use nft_protocol::object_box::{Self as obox, ObjectBox};
     use nft_protocol::inventory::{Self, Inventory};
@@ -302,7 +302,7 @@ module nft_protocol::launchpad {
     public fun add_nft<C>(
         slot: &mut Slot,
         market_id: ID,
-        nft: NFT<C>,
+        nft: Nft<C>,
     ) {
         let inventory = inventory_mut(slot, market_id);
 
@@ -321,7 +321,7 @@ module nft_protocol::launchpad {
         slot: &mut Slot,
         recipient: address,
     ) {
-        let nft = dof::remove<ID, NFT<C>>(
+        let nft = dof::remove<ID, Nft<C>>(
             &mut slot.id,
             certificate.nft_id,
         );

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -1,4 +1,4 @@
-//! Module of a generic `NFT` type.
+//! Module of a generic `Nft` type.
 //!
 //! It acts as a generic interface for NFTs and it allows for
 //! the creation of arbitrary domain specific implementations.
@@ -12,14 +12,14 @@ module nft_protocol::nft {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct NFT<phantom C> has key, store {
+    struct Nft<phantom C> has key, store {
         id: UID,
         bag: Bag,
         logical_owner: address,
     }
 
-    public fun new<C>(ctx: &mut TxContext): NFT<C> {
-        NFT {
+    public fun new<C>(ctx: &mut TxContext): Nft<C> {
+        Nft {
             id: object::new(ctx),
             bag: bag::new(ctx),
             logical_owner: tx_context::sender(ctx),
@@ -28,24 +28,24 @@ module nft_protocol::nft {
 
     // === Domain Functions ===
 
-    public fun has_domain<C, D: store>(nft: &NFT<C>): bool {
+    public fun has_domain<C, D: store>(nft: &Nft<C>): bool {
         bag::contains_with_type<Marker<D>, D>(&nft.bag, utils::marker<D>())
     }
 
-    public fun borrow_domain<C, D: store>(nft: &NFT<C>): &D {
+    public fun borrow_domain<C, D: store>(nft: &Nft<C>): &D {
         bag::borrow<Marker<D>, D>(&nft.bag, utils::marker<D>())
     }
 
     public fun borrow_domain_mut<C, D: store, W: drop>(
         _witness: W,
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
     ): &mut D {
         utils::assert_same_module_as_witness<W, D>();
         bag::borrow_mut<Marker<D>, D>(&mut nft.bag, utils::marker<D>())
     }
 
     public fun add_domain<C, V: store>(
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
         v: V,
         ctx: &mut TxContext,
     ) {
@@ -61,7 +61,7 @@ module nft_protocol::nft {
 
     public fun remove_domain<C, W: drop, V: store>(
         _witness: W,
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
     ): V {
         utils::assert_same_module_as_witness<W, V>();
         bag::remove(&mut nft.bag, utils::marker<V>())
@@ -72,7 +72,7 @@ module nft_protocol::nft {
     /// If the authority was whitelisted by the creator, we transfer
     /// the NFT to the recipient address.
     public fun transfer<C, Auth: drop>(
-        nft: NFT<C>,
+        nft: Nft<C>,
         recipient: address,
         authority: Auth,
         whitelist: &Whitelist,
@@ -83,7 +83,7 @@ module nft_protocol::nft {
 
     /// Whitelisted contracts (by creator) can change logical owner of an NFT.
     public fun change_logical_owner<C, Auth: drop>(
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
         recipient: address,
         authority: Auth,
         whitelist: &Whitelist,

--- a/sources/safe/safe.move
+++ b/sources/safe/safe.move
@@ -7,7 +7,7 @@ module nft_protocol::safe {
     use sui::transfer::{share_object, transfer};
 
     use nft_protocol::err;
-    use nft_protocol::nft::NFT;
+    use nft_protocol::nft::Nft;
     use nft_protocol::transfer_whitelist::Whitelist;
     use nft_protocol::unprotected_safe::{Self, UnprotectedSafe, TransferCap, OwnerCap};
 
@@ -142,7 +142,7 @@ module nft_protocol::safe {
     /// Requires that `enable_any_deposit` flag is set to true, or that the
     /// `Safe` owner enabled NFTs of given collection to be inserted.
     public entry fun deposit_nft<T>(
-        nft: NFT<T>,
+        nft: Nft<T>,
         safe: &mut Safe,
         ctx: &mut TxContext,
     ) {
@@ -152,7 +152,7 @@ module nft_protocol::safe {
 
     /// Transfer an NFT from owner to the `Safe`.
     public entry fun deposit_nft_priviledged<T>(
-        nft: NFT<T>,
+        nft: Nft<T>,
         owner_cap: &OwnerCap,
         safe: &mut Safe,
         ctx: &mut TxContext,

--- a/sources/safe/unprotected_safe.move
+++ b/sources/safe/unprotected_safe.move
@@ -1,6 +1,6 @@
 module nft_protocol::unprotected_safe {
     use nft_protocol::err;
-    use nft_protocol::nft::{Self, NFT};
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::transfer_whitelist::Whitelist;
 
     use sui::event;
@@ -159,7 +159,7 @@ module nft_protocol::unprotected_safe {
 
     /// Transfer an NFT into the `Safe`.
     public entry fun deposit_nft<T>(
-        nft: NFT<T>,
+        nft: Nft<T>,
         safe: &mut UnprotectedSafe,
         ctx: &mut TxContext,
     ) {
@@ -262,7 +262,7 @@ module nft_protocol::unprotected_safe {
     }
 
     fun deposit_nft_<T>(
-        nft: NFT<T>,
+        nft: Nft<T>,
         safe: &mut UnprotectedSafe,
         ctx: &mut TxContext,
     ) {
@@ -287,7 +287,7 @@ module nft_protocol::unprotected_safe {
     fun get_nft_for_transfer_<T>(
         transfer_cap: TransferCap,
         safe: &mut UnprotectedSafe,
-    ): NFT<T> {
+    ): Nft<T> {
         let nft_id = transfer_cap.nft;
 
         event::emit(
@@ -313,13 +313,13 @@ module nft_protocol::unprotected_safe {
         } = transfer_cap;
         object::delete(id);
 
-        dof::remove<ID, NFT<T>>(&mut safe.id, nft_id)
+        dof::remove<ID, Nft<T>>(&mut safe.id, nft_id)
     }
 
     // === Getters ===
 
     public fun has_nft<C>(nft: ID, safe: &UnprotectedSafe): bool {
-        dof::exists_with_type<ID, NFT<C>>(&safe.id, nft)
+        dof::exists_with_type<ID, Nft<C>>(&safe.id, nft)
     }
 
     public fun owner_cap_safe(cap: &OwnerCap): ID {

--- a/sources/standards/display.move
+++ b/sources/standards/display.move
@@ -5,7 +5,7 @@ module nft_protocol::display {
     use sui::url::Url;
     use sui::tx_context::{Self, TxContext};
 
-    use nft_protocol::nft::{Self, NFT};
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::collection::{Self, Collection, MintCap};
     use nft_protocol::attribution;
 
@@ -73,7 +73,7 @@ module nft_protocol::display {
     /// ====== Interoperability ===
 
     public fun display_domain<C>(
-        nft: &NFT<C>,
+        nft: &Nft<C>,
     ): &DisplayDomain {
         nft::borrow_domain(nft)
     }
@@ -85,7 +85,7 @@ module nft_protocol::display {
     }
 
     public fun add_display_domain<C>(
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
         name: String,
         description: String,
         ctx: &mut TxContext,
@@ -140,7 +140,7 @@ module nft_protocol::display {
 
     /// ====== Interoperability ===
 
-    public fun display_url<C>(nft: &NFT<C>): Option<Url> {
+    public fun display_url<C>(nft: &Nft<C>): Option<Url> {
         if (!nft::has_domain<C, UrlDomain>(nft)) {
             return option::none()
         };
@@ -157,7 +157,7 @@ module nft_protocol::display {
     }
 
     public fun add_url_domain<C>(
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
         url: Url,
         ctx: &mut TxContext
     ) {
@@ -208,7 +208,7 @@ module nft_protocol::display {
 
     /// ====== Interoperability ===
 
-    public fun display_symbol<C>(nft: &NFT<C>): Option<String> {
+    public fun display_symbol<C>(nft: &Nft<C>): Option<String> {
         if (!nft::has_domain<C, SymbolDomain>(nft)) {
             return option::none()
         };
@@ -227,7 +227,7 @@ module nft_protocol::display {
     }
 
     public fun add_symbol_domain<C>(
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
         symbol: String,
         ctx: &mut TxContext
     ) {

--- a/sources/standards/tags.move
+++ b/sources/standards/tags.move
@@ -3,7 +3,7 @@ module nft_protocol::tags {
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::utils::{Self, Marker};
-    use nft_protocol::nft::{Self, NFT};
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::collection::{Self, Collection, MintCap};
     use nft_protocol::attribution;
 
@@ -108,7 +108,7 @@ module nft_protocol::tags {
     /// ====== Interoperability ===
 
     public fun tag_domain<C>(
-        nft: &NFT<C>,
+        nft: &Nft<C>,
     ): &TagDomain {
         nft::borrow_domain(nft)
     }
@@ -132,7 +132,7 @@ module nft_protocol::tags {
     }
 
     public fun add_tag_domain<C>(
-        nft: &mut NFT<C>,
+        nft: &mut Nft<C>,
         tags: TagDomain,
         ctx: &mut TxContext,
     ) {

--- a/tests/safe.move
+++ b/tests/safe.move
@@ -1,6 +1,6 @@
 #[test_only]
 module nft_protocol::test_safe {
-    use nft_protocol::nft::{Self, NFT};
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::safe::{Self, Safe};
     use nft_protocol::unprotected_safe::OwnerCap;
     use nft_protocol::transfer_whitelist::{Self, Whitelist};
@@ -284,7 +284,7 @@ module nft_protocol::test_safe {
         );
         assert!(!safe::has_nft<Foo>(nft_id, &safe), 0);
         test_scenario::next_tx(&mut scenario, USER);
-        let nft = test_scenario::take_from_sender<NFT<Foo>>(&scenario);
+        let nft = test_scenario::take_from_sender<Nft<Foo>>(&scenario);
         safe::deposit_nft<Foo>(
             nft,
             &mut safe,
@@ -366,7 +366,7 @@ module nft_protocol::test_safe {
         );
         assert!(!safe::has_nft<Foo>(nft_id, &safe), 0);
         test_scenario::next_tx(&mut scenario, USER);
-        let nft = test_scenario::take_from_sender<NFT<Foo>>(&scenario);
+        let nft = test_scenario::take_from_sender<Nft<Foo>>(&scenario);
         safe::deposit_nft<Foo>(
             nft,
             &mut safe,


### PR DESCRIPTION
Struct names in capital letters, equal to the name of their module, are reserved to [One-Time Witnesses](https://examples.sui.io/basics/one-time-witness.html).