### PR TITLE
Removing the argument for enabling any deposit when creating a new Safe

### DIFF
--- a/sources/safe/safe.move
+++ b/sources/safe/safe.move
@@ -9,7 +9,7 @@ module nft_protocol::safe {
     use nft_protocol::err;
     use nft_protocol::nft::Nft;
     use nft_protocol::transfer_whitelist::Whitelist;
-    use nft_protocol::unprotected_safe::{Self, UnprotectedSafe, TransferCap, OwnerCap};
+    use nft_protocol::unprotected_safe::{Self, UnprotectedSafe};
 
     struct Safe has key, store {
         id: UID,
@@ -20,16 +20,35 @@ module nft_protocol::safe {
         collections_with_enabled_deposits: VecSet<TypeName>,
     }
 
+    /// Whoever owns this object can perform some admin actions against the
+    /// `Safe` shared object with the corresponding id.
+    struct OwnerCap has key, store {
+        id: UID,
+        inner: unprotected_safe::OwnerCap,
+    }
+
+    /// Enables the owner to transfer given NFT out of the `Safe`.
+    struct TransferCap has key, store {
+        id: UID,
+        inner: unprotected_safe::TransferCap,
+    }
+
+    /// Creates a new safe.
+    ///
+    /// Enables all deposits by default.
     public fun new(
-        enable_any_deposit: bool,
         ctx: &mut TxContext,
     ): (Safe, OwnerCap) {
         let (inner, cap) = unprotected_safe::new(ctx);
         let safe = Safe {
             id: object::new(ctx),
             inner,
-            enable_any_deposit,
+            enable_any_deposit: true,
             collections_with_enabled_deposits: vec_set::empty(),
+        };
+        let cap = OwnerCap {
+            id: object::new(ctx),
+            inner: cap,
         };
 
         (safe, cap)
@@ -37,11 +56,12 @@ module nft_protocol::safe {
 
     /// Instantiates a new shared object `Safe` and transfer
     /// `OwnerCap` to the tx sender.
+    ///
+    /// Enables all deposits by default.
     public entry fun create_for_sender(
-        enable_any_deposit: bool,
         ctx: &mut TxContext,
     ) {
-        let (safe, cap) = new(enable_any_deposit, ctx);
+        let (safe, cap) = new(ctx);
         share_object(safe);
 
         transfer(cap, tx_context::sender(ctx));
@@ -50,11 +70,12 @@ module nft_protocol::safe {
 
     /// Creates a new `Safe` shared object and returns the
     /// authority capability that grants authority over this safe.
+    ///
+    /// Enables all deposits by default.
     public fun create_safe(
-        enable_any_deposit: bool,
         ctx: &mut TxContext,
     ): OwnerCap {
-        let (safe, cap) = new(enable_any_deposit, ctx);
+        let (safe, cap) = new(ctx);
         share_object(safe);
 
         cap
@@ -70,9 +91,12 @@ module nft_protocol::safe {
         safe: &mut Safe,
         ctx: &mut TxContext,
     ): TransferCap {
-        unprotected_safe::create_transfer_cap(
-            nft, owner_cap, &mut safe.inner, ctx
-        )
+        TransferCap {
+            id: object::new(ctx),
+            inner: unprotected_safe::create_transfer_cap(
+                nft, &owner_cap.inner, &mut safe.inner, ctx
+            ),
+        }
     }
 
     /// Creates an irrevocable and exclusive transfer cap.
@@ -84,9 +108,12 @@ module nft_protocol::safe {
         safe: &mut Safe,
         ctx: &mut TxContext,
     ): TransferCap {
-        unprotected_safe::create_exclusive_transfer_cap(
-            nft, owner_cap, &mut safe.inner, ctx
-        )
+        TransferCap {
+            id: object::new(ctx),
+            inner: unprotected_safe::create_exclusive_transfer_cap(
+                nft, &owner_cap.inner, &mut safe.inner, ctx
+            )
+        }
     }
 
     /// Only owner or whitelisted collections can deposit.
@@ -173,8 +200,17 @@ module nft_protocol::safe {
         whitelist: &Whitelist,
         safe: &mut Safe,
     ) {
+        let TransferCap {
+            id, inner,
+        } = transfer_cap;
+        object::delete(id);
+
         unprotected_safe::transfer_nft_to_recipient<T, Auth>(
-            transfer_cap, recipient, authority, whitelist, &mut safe.inner
+            inner,
+            recipient,
+            authority,
+            whitelist,
+            &mut safe.inner
         )
     }
 
@@ -194,8 +230,13 @@ module nft_protocol::safe {
         target: &mut Safe,
         ctx: &mut TxContext,
     ) {
+        let TransferCap {
+            id, inner,
+        } = transfer_cap;
+        object::delete(id);
+
         unprotected_safe::transfer_nft_to_safe<T, Auth>(
-            transfer_cap,
+            inner,
             recipient,
             authority,
             whitelist,
@@ -211,7 +252,12 @@ module nft_protocol::safe {
         transfer_cap: TransferCap,
         safe: &mut Safe,
     ) {
-        unprotected_safe::burn_transfer_cap(transfer_cap, &mut safe.inner)
+        let TransferCap {
+            id, inner,
+        } = transfer_cap;
+        object::delete(id);
+
+        unprotected_safe::burn_transfer_cap(inner, &mut safe.inner)
     }
 
     /// Changes the transfer ref version, thereby invalidating all existing
@@ -224,7 +270,7 @@ module nft_protocol::safe {
         safe: &mut Safe,
         ctx: &mut TxContext,
     ) {
-        unprotected_safe::delist_nft(nft, owner_cap, &mut safe.inner, ctx)
+        unprotected_safe::delist_nft(nft, &owner_cap.inner, &mut safe.inner, ctx)
     }
 
     // === Getters ===
@@ -238,23 +284,23 @@ module nft_protocol::safe {
     }
 
     public fun owner_cap_safe(cap: &OwnerCap): ID {
-        unprotected_safe::owner_cap_safe(cap)
+        unprotected_safe::owner_cap_safe(&cap.inner)
     }
 
     public fun transfer_cap_safe(cap: &TransferCap): ID {
-        unprotected_safe::transfer_cap_safe(cap)
+        unprotected_safe::transfer_cap_safe(&cap.inner)
     }
 
     public fun transfer_cap_nft(cap: &TransferCap): ID {
-        unprotected_safe::transfer_cap_nft(cap)
+        unprotected_safe::transfer_cap_nft(&cap.inner)
     }
 
     public fun transfer_cap_version(cap: &TransferCap): ID {
-        unprotected_safe::transfer_cap_version(cap)
+        unprotected_safe::transfer_cap_version(&cap.inner)
     }
 
     public fun transfer_cap_is_exclusive(cap: &TransferCap): bool {
-        unprotected_safe::transfer_cap_is_exclusive(cap)
+        unprotected_safe::transfer_cap_is_exclusive(&cap.inner)
     }
 
     public fun are_all_deposits_enabled(safe: &Safe): bool {
@@ -264,15 +310,15 @@ module nft_protocol::safe {
     // === Assertions ===
 
     public fun assert_owner_cap(cap: &OwnerCap, safe: &Safe) {
-        unprotected_safe::assert_owner_cap(cap, &safe.inner)
+        unprotected_safe::assert_owner_cap(&cap.inner, &safe.inner)
     }
 
     public fun assert_transfer_cap_of_safe(cap: &TransferCap, safe: &Safe) {
-        unprotected_safe::assert_transfer_cap_of_safe(cap, &safe.inner)
+        unprotected_safe::assert_transfer_cap_of_safe(&cap.inner, &safe.inner)
     }
 
     public fun assert_nft_of_transfer_cap(nft: &ID, cap: &TransferCap) {
-        unprotected_safe::assert_nft_of_transfer_cap(nft, cap)
+        unprotected_safe::assert_nft_of_transfer_cap(nft, &cap.inner)
     }
 
     public fun assert_contains_nft(nft: &ID, safe: &Safe) {
@@ -280,13 +326,13 @@ module nft_protocol::safe {
     }
 
     public fun assert_not_exclusively_listed(cap: &TransferCap) {
-        unprotected_safe::assert_not_exclusively_listed(cap)
+        unprotected_safe::assert_not_exclusively_listed(&cap.inner)
     }
 
     public fun assert_version_match(
         ref: &unprotected_safe::NftRef, cap: &TransferCap
     ) {
-        unprotected_safe::assert_version_match(ref, cap)
+        unprotected_safe::assert_version_match(ref, &cap.inner)
     }
 
     public fun assert_can_deposit<T>(safe: &Safe) {

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -1,8 +1,7 @@
 module nft_protocol::bidding {
     use nft_protocol::err;
     use nft_protocol::royalties;
-    use nft_protocol::safe::{Self, Safe};
-    use nft_protocol::unprotected_safe::TransferCap;
+    use nft_protocol::safe::{Self, Safe, TransferCap};
     use nft_protocol::transfer_whitelist::Whitelist;
 
     use std::option::{Self, Option};

--- a/tests/safe.move
+++ b/tests/safe.move
@@ -1,8 +1,7 @@
 #[test_only]
 module nft_protocol::test_safe {
     use nft_protocol::nft::{Self, Nft};
-    use nft_protocol::safe::{Self, Safe};
-    use nft_protocol::unprotected_safe::OwnerCap;
+    use nft_protocol::safe::{Self, Safe, OwnerCap};
     use nft_protocol::transfer_whitelist::{Self, Whitelist};
     use sui::object;
     use sui::tx_context;
@@ -19,7 +18,7 @@ module nft_protocol::test_safe {
     fun it_creates_safe() {
         let scenario = test_scenario::begin(USER);
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
         let owner_cap_safe_id = safe::owner_cap_safe(&owner_cap);
 
         test_scenario::next_tx(&mut scenario, USER);
@@ -39,7 +38,7 @@ module nft_protocol::test_safe {
     fun it_fails_if_safe_id_mismatches() {
         let scenario = test_scenario::begin(USER);
 
-        safe::create_for_sender(true, ctx(&mut scenario));
+        safe::create_for_sender(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -56,7 +55,7 @@ module nft_protocol::test_safe {
     fun it_create_for_sender() {
         let scenario = test_scenario::begin(USER);
 
-        safe::create_for_sender(true, ctx(&mut scenario));
+        safe::create_for_sender(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -74,7 +73,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        safe::create_for_sender(true, ctx(&mut scenario));
+        safe::create_for_sender(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -99,11 +98,12 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(false, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
         let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::restrict_deposits(&owner_cap, &mut safe);
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
         safe::deposit_nft<Foo>(
@@ -123,7 +123,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -147,11 +147,12 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(false, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
         let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::restrict_deposits(&owner_cap, &mut safe);
         safe::enable_deposits_of_collection<Foo>(&owner_cap, &mut safe);
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
@@ -174,11 +175,12 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(false, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
         let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::restrict_deposits(&owner_cap, &mut safe);
         safe::enable_deposits_of_collection<Foo>(&owner_cap, &mut safe);
         safe::disable_deposits_of_collection<Foo>(&owner_cap, &mut safe);
 
@@ -199,7 +201,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -239,7 +241,7 @@ module nft_protocol::test_safe {
     fun it_cannot_create_transfer_cap_if_nft_not_present() {
         let scenario = test_scenario::begin(USER);
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -263,7 +265,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -311,7 +313,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -346,7 +348,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -395,7 +397,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -462,7 +464,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -501,11 +503,12 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(false, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
         let safe: Safe = test_scenario::take_shared(&scenario);
+        safe::restrict_deposits(&owner_cap, &mut safe);
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
         safe::deposit_nft_priviledged<Foo>(
@@ -525,11 +528,11 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap1 = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap1 = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe1: Safe = test_scenario::take_shared(&scenario);
 
-        let owner_cap2 = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap2 = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe2: Safe = test_scenario::take_shared(&scenario);
 
@@ -578,7 +581,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -621,7 +624,7 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let owner_cap = safe::create_safe(ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -671,11 +674,11 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let right_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe: Safe = test_scenario::take_shared(&scenario);
 
-        let wrong_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
         let nft_id = object::id(&nft);
@@ -708,11 +711,11 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let right_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe: Safe = test_scenario::take_shared(&scenario);
 
-        let wrong_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
         let nft_id = object::id(&nft);
@@ -744,11 +747,11 @@ module nft_protocol::test_safe {
     fun it_fails_to_accepts_any_deposit_on_wrong_owner_cap() {
         let scenario = test_scenario::begin(USER);
 
-        let right_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe: Safe = test_scenario::take_shared(&scenario);
 
-        let wrong_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
 
         safe::enable_any_deposit(&wrong_owner_cap, &mut safe);
 
@@ -766,11 +769,11 @@ module nft_protocol::test_safe {
     fun it_fails_to_enable_deposits_of_collection_on_wrong_owner_cap() {
         let scenario = test_scenario::begin(USER);
 
-        let right_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe: Safe = test_scenario::take_shared(&scenario);
 
-        let wrong_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
 
         safe::enable_deposits_of_collection<Foo>(&wrong_owner_cap, &mut safe);
 
@@ -789,11 +792,11 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let right_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe: Safe = test_scenario::take_shared(&scenario);
 
-        let wrong_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
         safe::deposit_nft_priviledged<Foo>(
@@ -818,11 +821,11 @@ module nft_protocol::test_safe {
         let scenario = test_scenario::begin(USER);
         let sender = tx_context::sender(ctx(&mut scenario));
 
-        let right_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let right_owner_cap = safe::create_safe(ctx(&mut scenario));
         test_scenario::next_tx(&mut scenario, USER);
         let safe: Safe = test_scenario::take_shared(&scenario);
 
-        let wrong_owner_cap = safe::create_safe(true, ctx(&mut scenario));
+        let wrong_owner_cap = safe::create_safe(ctx(&mut scenario));
 
         let nft = nft::new<Foo>(sender, ctx(&mut scenario));
         let nft_id = object::id(&nft);


### PR DESCRIPTION
The default behavior is that anyone can deposit NFTs into a safe. Optionally, one can call the `restrict_deposits` method to configure the safe.

Why default to true? It's the more common use case for trading and games, making it simpler for usage. The devs need to be aware of how safe works anyway, plus we've got docs, so this isn't a security vuln imho.