### PR TITLE
Feature: Dutch auction market tests

### DIFF
--- a/sources/launchpad/inventory.move
+++ b/sources/launchpad/inventory.move
@@ -98,6 +98,12 @@ module nft_protocol::inventory {
         vector::length(&inventory.nfts)
     }
 
+    public fun is_empty(
+        inventory: &Inventory,
+    ): bool {
+        vector::is_empty(&inventory.nfts)
+    }
+
     public fun is_whitelisted(
         inventory: &Inventory,
     ): bool {

--- a/sources/launchpad/proceeds.move
+++ b/sources/launchpad/proceeds.move
@@ -1,8 +1,6 @@
 module nft_protocol::proceeds {
     // TODO: Function to destroy Proceeds object
     // TODO: reconsider `Proceeds.total` to acocmodate for multiple FTs
-    use std::type_name::{Self, TypeName};
-
     use sui::coin;
     use sui::transfer;
     use sui::tx_context::TxContext;
@@ -10,15 +8,12 @@ module nft_protocol::proceeds {
     use sui::balance::{Self, Balance};
     use sui::dynamic_field as df;
 
+    use nft_protocol::utils::{Self, Marker};
+
     struct Proceeds has key, store {
         id: UID,
         // Quantity of NFTs sold
         qt_sold: QtSold,
-        // Total FT-amount sold. The reason for storing this info is to allow
-        // for custom types of fees that rely on the total FT-amount sold.
-        // Marketplaces could then reduce the amount of fees charged based
-        // on the bulk-volume of the sale.
-        total: u64,
     }
 
     // Quantity of NFTs Sold
@@ -38,24 +33,7 @@ module nft_protocol::proceeds {
         Proceeds {
             id: object::new(ctx),
             qt_sold: QtSold {collected: 0, total: 0},
-            total: 0,
         }
-    }
-
-    public fun balance<FT>(proceeds: &Proceeds): &Balance<FT> {
-        df::borrow<TypeName, Balance<FT>>(
-            &proceeds.id,
-            type_name::get<Balance<FT>>(),
-        )
-    }
-
-    fun balance_mut<FT>(
-        proceeds: &mut Proceeds,
-    ): &mut Balance<FT> {
-        df::borrow_mut<TypeName, Balance<FT>>(
-            &mut proceeds.id,
-            type_name::get<Balance<FT>>(),
-        )
     }
 
     public fun add<FT>(
@@ -63,23 +41,23 @@ module nft_protocol::proceeds {
         new_proceeds: Balance<FT>,
         qty_sold: u64,
     ) {
-        proceeds.total = proceeds.total + balance::value(&new_proceeds);
         proceeds.qt_sold.total = proceeds.qt_sold.total + qty_sold;
 
-        let missing_df = !df::exists_with_type<TypeName, Balance<FT>>(
-            &proceeds.id, type_name::get<Balance<FT>>()
+        let marker = utils::marker<FT>();
+        let missing_df = !df::exists_with_type<Marker<FT>, Balance<FT>>(
+            &proceeds.id, marker
         );
 
         if (missing_df) {
-            df::add<TypeName, Balance<FT>>(
+            df::add<Marker<FT>, Balance<FT>>(
                 &mut proceeds.id,
-                type_name::get<Balance<FT>>(),
+                marker,
                 new_proceeds,
             )
         } else {
-            let balance = df::borrow_mut<TypeName, Balance<FT>>(
+            let balance = df::borrow_mut<Marker<FT>, Balance<FT>>(
                 &mut proceeds.id,
-                type_name::get<Balance<FT>>(),
+                marker,
             );
 
             balance::join(
@@ -96,9 +74,9 @@ module nft_protocol::proceeds {
         slot_receiver: address,
         ctx: &mut TxContext,
     ) {
-        let balance = df::borrow_mut<TypeName, Balance<FT>>(
+        let balance = df::borrow_mut<Marker<FT>, Balance<FT>>(
             &mut proceeds.id,
-            type_name::get<Balance<FT>>(),
+            utils::marker<FT>(),
         );
 
         let fee_balance = balance::split<FT>(
@@ -127,5 +105,31 @@ module nft_protocol::proceeds {
             proceeds_coin,
             slot_receiver,
         );
+    }
+
+    // === Getter Functions ===
+
+    public fun collected(proceeds: &Proceeds): u64 {
+        proceeds.qt_sold.collected
+    }
+
+    public fun total(proceeds: &Proceeds): u64 {
+        proceeds.qt_sold.total
+    }
+
+    public fun balance<FT>(proceeds: &Proceeds): &Balance<FT> {
+        df::borrow<Marker<FT>, Balance<FT>>(
+            &proceeds.id,
+            utils::marker<FT>(),
+        )
+    }
+
+    fun balance_mut<FT>(
+        proceeds: &mut Proceeds,
+    ): &mut Balance<FT> {
+        df::borrow_mut<Marker<FT>, Balance<FT>>(
+            &mut proceeds.id,
+            utils::marker<FT>(),
+        )
     }
 }

--- a/sources/launchpad/slot.move
+++ b/sources/launchpad/slot.move
@@ -2,7 +2,7 @@ module nft_protocol::slot {
     // TODO: Consider adding a function redeem_certificate with `nft_id` as
     // a parameter
     use sui::transfer;
-    use sui::coin::{Self, Coin};
+    use sui::balance::Balance;
     use sui::object::{Self, ID , UID};
     use sui::dynamic_object_field as dof;
     use sui::tx_context::{Self, TxContext};
@@ -270,12 +270,10 @@ module nft_protocol::slot {
 
     public fun pay<FT>(
         slot: &mut Slot,
-        funds: Coin<FT>,
+        balance: Balance<FT>,
         qty_sold: u64,
     ) {
-        let balance = coin::into_balance(funds);
         let proceeds = proceeds_mut(slot);
-
         proceeds::add(proceeds, balance, qty_sold);
     }
 
@@ -393,7 +391,7 @@ module nft_protocol::slot {
     // === Getter functions ===
 
     /// Get the Slot's `live`
-    public fun live(slot: &Slot): bool {
+    public fun is_live(slot: &Slot): bool {
         slot.live
     }
 
@@ -460,7 +458,7 @@ module nft_protocol::slot {
         slot: &mut Slot,
         market_id: ID,
     ): &mut Market {
-        utils::assert_same_module_as_witness<Witness, Market>();
+        utils::assert_same_module_as_witness<Market, Witness>();
         assert_market<Market>(slot, market_id);
         object_bag::borrow_mut<ID, Market>(&mut slot.markets, market_id)
     }

--- a/tests/market/dutch_auction.move
+++ b/tests/market/dutch_auction.move
@@ -1,4 +1,716 @@
 #[test_only]
 module nft_protocol::test_dutch_auction {
+    use std::vector;
 
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+    use sui::balance;
+    use sui::transfer;
+    use sui::object::{Self, ID};
+    use sui::test_scenario::{Self, Scenario, ctx};
+
+    use movemate::crit_bit_u64 as crit_bit;
+
+    use nft_protocol::nft;
+    use nft_protocol::proceeds;
+    use nft_protocol::inventory;
+    use nft_protocol::slot::{Self, NftCertificate, WhitelistCertificate, Slot};
+    use nft_protocol::dutch_auction::{Self, DutchAuctionMarket};
+
+    use nft_protocol::test_slot::init_slot;
+
+    struct COLLECTION {}
+
+    const CREATOR: address = @0xA1C05;
+    const BUYER: address = @0xA1C06;
+
+    fun init_market(
+        slot: &mut Slot,
+        reserve_price: u64,
+        is_whitelisted: bool,
+        scenario: &mut Scenario,
+    ): ID {
+        let market = dutch_auction::new<SUI>(reserve_price, ctx(scenario));
+        let market_id = object::id(&market);
+
+        slot::add_market(
+            slot,
+            market,
+            inventory::new(is_whitelisted, ctx(scenario)),
+            ctx(scenario)
+        );
+
+        market_id
+    }
+
+    #[test]
+    fun create_market() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        let _market: &DutchAuctionMarket<SUI> = slot::market(&slot, market_id);
+
+        assert!(dutch_auction::reserve_price<SUI>(&slot, market_id) == 10, 0);
+
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370202, location = nft_protocol::slot)]
+    fun try_bid_not_live() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370303, location = nft_protocol::dutch_auction)]
+    fun try_bid_lower_than_reserve() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            9,
+            1,
+            ctx(&mut scenario),
+        );
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun bid_nft() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(49, ctx(&mut scenario));
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            12,
+            2,
+            ctx(&mut scenario),
+        );
+
+        assert!(coin::value(&wallet) == 5, 0);
+
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+
+        // Test bids at price level 10
+        let level = crit_bit::borrow(bids, 10);
+        let bid = vector::borrow(level, 0);
+        assert!(dutch_auction::bid_owner(bid) == BUYER, 0);
+        assert!(balance::value(dutch_auction::bid_amount(bid)) == 10, 0);
+        let bid = vector::borrow(level, 1);
+        assert!(dutch_auction::bid_owner(bid) == CREATOR, 0);
+        assert!(balance::value(dutch_auction::bid_amount(bid)) == 10, 0);
+
+        // Test bids at price level 12
+        let level = crit_bit::borrow(bids, 12);
+        let bid = vector::borrow(level, 0);
+        assert!(dutch_auction::bid_owner(bid) == CREATOR, 0);
+        assert!(balance::value(dutch_auction::bid_amount(bid)) == 12, 0);
+        let bid = vector::borrow(level, 1);
+        assert!(dutch_auction::bid_owner(bid) == CREATOR, 0);
+        assert!(balance::value(dutch_auction::bid_amount(bid)) == 12, 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370206, location = nft_protocol::slot)]
+    fun try_bid_whitelisted_nft() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, true, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun bid_whitelisted_nft() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, true, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        slot::transfer_whitelist_certificate(
+            &launchpad, &slot, market_id, BUYER, ctx(&mut scenario)
+        );
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let certificate = test_scenario::take_from_address<
+            WhitelistCertificate
+        >(&scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(15, ctx(&mut scenario));
+        dutch_auction::create_bid_whitelisted<SUI>(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            certificate,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        assert!(coin::value(&wallet) == 5, 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370302, location = nft_protocol::dutch_auction)]
+    fun cancel_bid_does_not_exist() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(44, ctx(&mut scenario));
+        
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        slot::sale_off(&launchpad, &mut slot, ctx(&mut scenario));
+
+        dutch_auction::cancel_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            ctx(&mut scenario),
+        );
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun cancel_bid() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        let wallet = coin::mint_for_testing<SUI>(44, ctx(&mut scenario));
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        let level = crit_bit::borrow(bids, 10);
+        assert!(vector::length(level) == 3, 0);
+        let bid = vector::borrow(level, 0);
+        assert!(dutch_auction::bid_owner(bid) == BUYER, 0);
+        let bid = vector::borrow(level, 1);
+        assert!(dutch_auction::bid_owner(bid) == CREATOR, 0);
+        let bid = vector::borrow(level, 2);
+        assert!(dutch_auction::bid_owner(bid) == BUYER, 0);
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        dutch_auction::cancel_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            ctx(&mut scenario),
+        );
+
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        let level = crit_bit::borrow(bids, 10);
+        assert!(vector::length(level) == 2, 0);
+        let bid = vector::borrow(level, 0);
+        assert!(dutch_auction::bid_owner(bid) == CREATOR, 0);
+        let bid = vector::borrow(level, 1);
+        assert!(dutch_auction::bid_owner(bid) == BUYER, 0);
+
+        dutch_auction::cancel_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            ctx(&mut scenario),
+        );
+
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        let level = crit_bit::borrow(bids, 10);
+        assert!(vector::length(level) == 1, 0);
+        let bid = vector::borrow(level, 0);
+        assert!(dutch_auction::bid_owner(bid) == CREATOR, 0);
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        dutch_auction::cancel_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            ctx(&mut scenario),
+        );
+
+        assert!(coin::value(&wallet) == 44, 0);
+
+        // Check that price levels are automatically removed once empty
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        assert!(crit_bit::is_empty(bids), 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun cancel_while_not_live() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        let wallet = coin::mint_for_testing<SUI>(44, ctx(&mut scenario));
+        
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        // Bids should be cancellable even if slot is turned off
+        slot::sale_off(&launchpad, &mut slot, ctx(&mut scenario));
+
+        dutch_auction::cancel_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            ctx(&mut scenario),
+        );
+
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        assert!(crit_bit::is_empty(bids), 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370212, location = nft_protocol::slot)]
+    fun try_cancel_auction() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        dutch_auction::sale_cancel<SUI>(
+            &launchpad,
+            &mut slot,
+            market_id,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun cancel_auction() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        let wallet = coin::mint_for_testing<SUI>(44, ctx(&mut scenario));
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            12,
+            1,
+            ctx(&mut scenario),
+        );
+
+        dutch_auction::sale_cancel<SUI>(
+            &launchpad,
+            &mut slot,
+            market_id,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        // Slot should be automatically turned off after cancelling the auction
+        assert!(!slot::is_live(&slot), 0);
+
+        // Check wallet balances
+        assert!(coin::value(&wallet) == 22, 0);
+
+        let refunded = test_scenario::take_from_address<Coin<SUI>>(
+            &scenario,
+            BUYER,
+        );
+        assert!(coin::value(&refunded) == 10, 0);
+        test_scenario::return_to_address(BUYER, refunded);
+
+        let refunded = test_scenario::take_from_address<Coin<SUI>>(
+            &scenario,
+            CREATOR,
+        );
+        assert!(coin::value(&refunded) == 12, 0);
+        test_scenario::return_to_address(CREATOR, refunded);
+
+        // Check bid state
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        assert!(crit_bit::is_empty(bids), 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370212, location = nft_protocol::slot)]
+    fun try_conclude_auction() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+
+        test_scenario::next_tx(&mut scenario, BUYER);
+
+        dutch_auction::sale_conclude<SUI>(
+            &launchpad,
+            &mut slot,
+            market_id,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun conclude_auction() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        
+        slot::add_nft(
+            &mut slot,
+            market_id,
+            nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
+            ctx(&mut scenario)
+        );
+
+        slot::add_nft(
+            &mut slot,
+            market_id,
+            nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
+            ctx(&mut scenario)
+        );
+        
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        let wallet = coin::mint_for_testing<SUI>(35, ctx(&mut scenario));
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            11,
+            1,
+            ctx(&mut scenario),
+        );
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            12,
+            1,
+            ctx(&mut scenario),
+        );
+
+        dutch_auction::sale_conclude<SUI>(
+            &launchpad,
+            &mut slot,
+            market_id,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        // Slot should be automatically turned off after concluding the auction
+        assert!(!slot::is_live(&slot), 0);
+
+        // Check certificates
+
+        let certificate0 = test_scenario::take_from_address<NftCertificate>(
+            &mut scenario, CREATOR
+        );
+        slot::assert_nft_certificate_slot(object::id(&slot), &certificate0);
+        
+        let certificate1 = test_scenario::take_from_address<NftCertificate>(
+            &mut scenario, CREATOR
+        );
+        slot::assert_nft_certificate_slot(object::id(&slot), &certificate1);
+        
+        test_scenario::return_to_address(CREATOR, certificate0);
+        test_scenario::return_to_address(CREATOR, certificate1);
+
+        // Check wallet balances
+        assert!(coin::value(&wallet) == 2, 0);
+
+        // Auction should have filled at 11
+        let proceeds = slot::proceeds(&slot);
+        assert!(proceeds::total(proceeds) == 2, 0);
+        assert!(balance::value(proceeds::balance<SUI>(proceeds)) == 22, 0);
+
+        // One bid should have been refunded and also some change
+        let refunded0 = test_scenario::take_from_address<Coin<SUI>>(
+            &scenario,
+            CREATOR,
+        );
+        assert!(coin::value(&refunded0) == 10, 0);
+
+        let refunded1 = test_scenario::take_from_address<Coin<SUI>>(
+            &scenario,
+            CREATOR,
+        );
+        assert!(coin::value(&refunded1) == 1, 0);
+
+        test_scenario::return_to_address(CREATOR, refunded0);
+        test_scenario::return_to_address(CREATOR, refunded1);
+
+        // Check bid state
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        assert!(crit_bit::is_empty(bids), 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun conclude_auction_not_all_sold() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        
+        slot::add_nft(
+            &mut slot,
+            market_id,
+            nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
+            ctx(&mut scenario)
+        );
+
+        slot::add_nft(
+            &mut slot,
+            market_id,
+            nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
+            ctx(&mut scenario)
+        );
+        
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+
+        let wallet = coin::mint_for_testing<SUI>(35, ctx(&mut scenario));
+
+        dutch_auction::create_bid(
+            &mut wallet,
+            &mut slot,
+            market_id,
+            10,
+            1,
+            ctx(&mut scenario),
+        );
+
+        dutch_auction::sale_conclude<SUI>(
+            &launchpad,
+            &mut slot,
+            market_id,
+            ctx(&mut scenario),
+        );
+
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        // Slot should not be turned off as all inventory has not been sold
+        assert!(slot::is_live(&slot), 0);
+
+        // Check bid state
+        let bids = dutch_auction::bids<SUI>(&slot, market_id);
+        assert!(crit_bit::is_empty(bids), 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
 }

--- a/tests/market/fixed_price.move
+++ b/tests/market/fixed_price.move
@@ -2,47 +2,21 @@
 module nft_protocol::test_fixed_price {
     use sui::sui::SUI;
     use sui::coin;
+    use sui::transfer;
     use sui::object::{Self, ID};
     use sui::test_scenario::{Self, Scenario, ctx};
 
     use nft_protocol::nft;
-    use nft_protocol::flat_fee;
     use nft_protocol::inventory;
     use nft_protocol::slot::{Self, Slot, NftCertificate, WhitelistCertificate};
-    use nft_protocol::launchpad::{Self, Launchpad};
     use nft_protocol::fixed_price::{Self, FixedPriceMarket};
+
+    use nft_protocol::test_slot::init_slot;
 
     struct COLLECTION {}
 
     const CREATOR: address = @0xA1C05;
     const BUYER: address = @0xA1C06;
-
-    fun init_slot(scenario: &mut Scenario): (Launchpad, Slot) {
-        test_scenario::next_tx(scenario, CREATOR);
-
-        launchpad::init_launchpad(
-            CREATOR,
-            CREATOR,
-            true,
-            flat_fee::new(0, ctx(scenario)),
-            ctx(scenario),
-        );
-
-        test_scenario::next_tx(scenario, CREATOR);
-        let launchpad = test_scenario::take_shared<Launchpad>(scenario);
-
-        slot::init_slot(
-            &launchpad,
-            CREATOR,
-            CREATOR,
-            ctx(scenario),
-        );
-
-        test_scenario::next_tx(scenario, CREATOR);
-        let slot = test_scenario::take_shared<Slot>(scenario);
-
-        (launchpad, slot)
-    }
 
     fun init_market(
         slot: &mut Slot,
@@ -66,11 +40,60 @@ module nft_protocol::test_fixed_price {
     #[test]
     fun create_market() {
         let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
-        let market_id = init_market(&mut slot, 0, false, &mut scenario);
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
         let _market: &FixedPriceMarket<SUI> = slot::market(&slot, market_id);
 
+        assert!(fixed_price::price<SUI>(&slot, market_id) == 10, 0);
+
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370202, location = nft_protocol::slot)]
+    fun try_buy_not_live() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
+        fixed_price::buy_nft_certificate(
+            &launchpad,
+            &mut slot,
+            market_id,
+            &mut wallet,
+            ctx(&mut scenario),
+        );
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::return_shared(slot);
+        test_scenario::return_shared(launchpad);
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370209, location = nft_protocol::inventory)]
+    fun try_buy_no_supply() {
+        let scenario = test_scenario::begin(CREATOR);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
+
+        let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        slot::sale_on(&mut slot, ctx(&mut scenario));
+        
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
+        fixed_price::buy_nft_certificate(
+            &launchpad,
+            &mut slot,
+            market_id,
+            &mut wallet,
+            ctx(&mut scenario),
+        );
+
+        transfer::transfer(wallet, BUYER);
         test_scenario::return_shared(slot);
         test_scenario::return_shared(launchpad);
         test_scenario::end(scenario);
@@ -79,27 +102,33 @@ module nft_protocol::test_fixed_price {
     #[test]
     fun buy_nft() {
         let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
+        
         slot::add_nft(
             &mut slot,
             market_id,
             nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
             ctx(&mut scenario)
         );
+
         slot::sale_on(&mut slot, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, BUYER);
 
+        let wallet = coin::mint_for_testing<SUI>(15, ctx(&mut scenario));
         fixed_price::buy_nft_certificate(
             &launchpad,
             &mut slot,
             market_id,
-            coin::mint_for_testing<SUI>(10, ctx(&mut scenario)),
+            &mut wallet,
             ctx(&mut scenario),
         );
 
+        assert!(coin::value(&wallet) == 5, 0);
+
+        transfer::transfer(wallet, BUYER);
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let certificate = test_scenario::take_from_address<NftCertificate>(
@@ -114,64 +143,29 @@ module nft_protocol::test_fixed_price {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370202, location = nft_protocol::slot)]
-    fun try_buy_not_live() {
-        let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
-
-        let market_id = init_market(&mut slot, 10, false, &mut scenario);
-
-        fixed_price::buy_nft_certificate(
-            &launchpad,
-            &mut slot,
-            market_id,
-            coin::mint_for_testing<SUI>(10, ctx(&mut scenario)),
-            ctx(&mut scenario),
-        );
-
-        test_scenario::return_shared(slot);
-        test_scenario::return_shared(launchpad);
-        test_scenario::end(scenario);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = 13370209, location = nft_protocol::inventory)]
-    fun try_buy_no_supply() {
-        let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
-
-        let market_id = init_market(&mut slot, 10, false, &mut scenario);
-        slot::sale_on(&mut slot, ctx(&mut scenario));
-
-        fixed_price::buy_nft_certificate(
-            &launchpad,
-            &mut slot,
-            market_id,
-            coin::mint_for_testing<SUI>(10, ctx(&mut scenario)),
-            ctx(&mut scenario),
-        );
-
-        test_scenario::return_shared(slot);
-        test_scenario::return_shared(launchpad);
-        test_scenario::end(scenario);
-    }
-
-    #[test]
     #[expected_failure(abort_code = 13370206, location = nft_protocol::slot)]
     fun try_buy_whitelisted_nft() {
         let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, true, &mut scenario);
         slot::sale_on(&mut slot, ctx(&mut scenario));
+        
+        test_scenario::next_tx(&mut scenario, BUYER);
 
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
         fixed_price::buy_nft_certificate(
             &launchpad,
             &mut slot,
             market_id,
-            coin::mint_for_testing<SUI>(10, ctx(&mut scenario)),
+            &mut wallet,
             ctx(&mut scenario),
         );
+
+        assert!(coin::value(&wallet) == 0, 0);
+
+        transfer::transfer(wallet, BUYER);
+        test_scenario::next_tx(&mut scenario, BUYER);
 
         let certificate = test_scenario::take_from_address<NftCertificate>(
             &mut scenario, BUYER
@@ -187,15 +181,17 @@ module nft_protocol::test_fixed_price {
     #[test]
     fun buy_whitelisted_nft() {
         let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, true, &mut scenario);
+        
         slot::add_nft(
             &mut slot,
             market_id,
             nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
             ctx(&mut scenario)
         );
+        
         slot::sale_on(&mut slot, ctx(&mut scenario));
 
         slot::transfer_whitelist_certificate(
@@ -208,15 +204,17 @@ module nft_protocol::test_fixed_price {
             WhitelistCertificate
         >(&scenario, BUYER);
 
+        let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
         fixed_price::buy_whitelisted_nft_certificate(
             &launchpad,
             &mut slot,
             market_id,
-            coin::mint_for_testing<SUI>(10, ctx(&mut scenario)),
+            &mut wallet,
             certificate,
             ctx(&mut scenario),
         );
 
+        transfer::transfer(wallet, BUYER);
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let certificate = test_scenario::take_from_address<NftCertificate>(
@@ -234,7 +232,7 @@ module nft_protocol::test_fixed_price {
     #[expected_failure(abort_code = 13370212, location = nft_protocol::slot)]
     fun try_change_price() {
         let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, true, &mut scenario);
 
@@ -252,7 +250,7 @@ module nft_protocol::test_fixed_price {
     #[test]
     fun change_price() {
         let scenario = test_scenario::begin(CREATOR);
-        let (launchpad, slot) = init_slot(&mut scenario);
+        let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, true, &mut scenario);
 
@@ -262,7 +260,7 @@ module nft_protocol::test_fixed_price {
             &mut slot, market_id, 20, ctx(&mut scenario)
         );
 
-        assert!(fixed_price::price<SUI>(&slot, market_id) == 20, 1);
+        assert!(fixed_price::price<SUI>(&slot, market_id) == 20, 0);
 
         test_scenario::return_shared(slot);
         test_scenario::return_shared(launchpad);

--- a/tests/slot.move
+++ b/tests/slot.move
@@ -1,0 +1,38 @@
+#[test_only]
+module nft_protocol::test_slot {
+    use sui::test_scenario::{Self, Scenario, ctx};
+
+    use nft_protocol::flat_fee;
+    use nft_protocol::slot::{Self, Slot};
+    use nft_protocol::launchpad::{Self, Launchpad};
+
+    public fun init_slot(
+        creator: address,
+        scenario: &mut Scenario,
+    ): (Launchpad, Slot) {
+        test_scenario::next_tx(scenario, creator);
+
+        launchpad::init_launchpad(
+            creator,
+            creator,
+            true,
+            flat_fee::new(0, ctx(scenario)),
+            ctx(scenario),
+        );
+
+        test_scenario::next_tx(scenario, creator);
+        let launchpad = test_scenario::take_shared<Launchpad>(scenario);
+
+        slot::init_slot(
+            &launchpad,
+            creator,
+            creator,
+            ctx(scenario),
+        );
+
+        test_scenario::next_tx(scenario, creator);
+        let slot = test_scenario::take_shared<Slot>(scenario);
+
+        (launchpad, slot)
+    }
+}


### PR DESCRIPTION
Adds dutch auction market tests
- Rearranged tests in fixed price market
- Changed wallet API in both markets
- Removed `Proceeds.total` due to potentially adding up different `FT`s, we can reintroduce it in a follow-up MR