### PR TITLE
Feature: Remove NFT Certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 sui.log.*
 .env
 build
+target
 output.bpl
 .coverage_*
 .trace

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -118,6 +118,6 @@ module nft_protocol::suimarines {
             ctx,
         );
 
-        inventory::add_nft(inventory, nft);
+        inventory::deposit_nft(inventory, nft);
     }
 }

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -151,6 +151,6 @@ module nft_protocol::suitraders {
             ctx,
         );
 
-        inventory::add_nft(inventory, nft);
+        inventory::deposit_nft(inventory, nft);
     }
 }

--- a/sources/launchpad/inventory.move
+++ b/sources/launchpad/inventory.move
@@ -115,8 +115,11 @@ module nft_protocol::inventory {
     /// Adds NFT as a dynamic child object with its ID as key
     public(friend) fun redeem_nft<C>(
         inventory: &mut Inventory,
-        nft_id: ID,
     ): Nft<C> {
+        let nfts = &mut inventory.nfts_on_sale;
+        assert!(!vector::is_empty(nfts), err::no_nfts_left());
+        let nft_id = vector::pop_back(nfts);
+
         let nft = dof::remove<ID, Nft<C>>(
             &mut inventory.id,
             nft_id,
@@ -137,16 +140,16 @@ module nft_protocol::inventory {
         vector::push_back(nfts, id);
     }
 
-    /// Pops an NFT's ID from the `nfts` field in `Inventory` object
-    /// and returns respective `ID`
-    /// TODO: Need to push the ID to the queue
-    public fun pop_nft_from_sale(
-        inventory: &mut Inventory,
-    ): ID {
-        let nfts = &mut inventory.nfts_on_sale;
-        assert!(!vector::is_empty(nfts), err::no_nfts_left());
-        vector::pop_back(nfts)
-    }
+    // /// Pops an NFT's ID from the `nfts` field in `Inventory` object
+    // /// and returns respective `ID`
+    // /// TODO: Need to push the ID to the queue
+    // public fun pop_nft_from_sale(
+    //     inventory: &mut Inventory,
+    // ): ID {
+    //     let nfts = &mut inventory.nfts_on_sale;
+    //     assert!(!vector::is_empty(nfts), err::no_nfts_left());
+    //     vector::pop_back(nfts)
+    // }
 
     /// Check how many `nfts` there are to sell
     public fun length(

--- a/sources/launchpad/market/dutch_auction.move
+++ b/sources/launchpad/market/dutch_auction.move
@@ -185,7 +185,7 @@ module nft_protocol::dutch_auction {
     /// NFTs will be allocated to the winning biddeers.
     ///
     /// Permissioned endpoint to be called by `admin`.
-    public entry fun sale_conclude<FT>(
+    public entry fun sale_conclude<C, FT>(
         launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
@@ -214,19 +214,10 @@ module nft_protocol::dutch_auction {
                 filled_funds
             );
 
-            let certificate = slot::issue_nft_certificate_internal<
-                DutchAuctionMarket<FT>, Witness
-            >(
+            slot::redeem_nft_and_transfer<C, DutchAuctionMarket<FT>, Witness>(
                 Witness {},
-                launchpad,
                 slot,
                 market_id,
-                ctx
-            );
-
-            // Transfer certificate to winning bid
-            transfer::transfer(
-                certificate,
                 owner,
             );
 

--- a/sources/launchpad/market/fixed_price.move
+++ b/sources/launchpad/market/fixed_price.move
@@ -79,7 +79,7 @@ module nft_protocol::fixed_price {
     /// A `NftCertificate` object will be minted and transfered to the sender
     /// of transaction. The sender can then use this certificate to call
     /// `claim_nft` and claim the NFT that has been allocated by the slingshot
-    public entry fun buy_nft_certificate<FT>(
+    public entry fun buy_nft_certificate<C, FT>(
         launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
@@ -88,7 +88,7 @@ module nft_protocol::fixed_price {
     ) {
         slot::assert_market_is_not_whitelisted(slot, market_id);
 
-        buy_nft_certificate_(
+        buy_nft_<C, FT>(
             launchpad,
             slot,
             market_id,
@@ -103,7 +103,7 @@ module nft_protocol::fixed_price {
     /// A `NftCertificate` object will be minted and transfered to the sender
     /// of transaction. The sender can then use this certificate to call
     /// `claim_nft` and claim the NFT that has been allocated by the slingshot
-    public entry fun buy_whitelisted_nft_certificate<FT>(
+    public entry fun buy_whitelisted_nft<C, FT>(
         launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
@@ -116,7 +116,7 @@ module nft_protocol::fixed_price {
 
         slot::burn_whitelist_certificate(whitelist_token);
 
-        buy_nft_certificate_(
+        buy_nft_<C, FT>(
             launchpad,
             slot,
             market_id,
@@ -125,7 +125,7 @@ module nft_protocol::fixed_price {
         )
     }
 
-    fun buy_nft_certificate_<FT>(
+    fun buy_nft_<C, FT>(
         launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
@@ -140,18 +140,10 @@ module nft_protocol::fixed_price {
         let funds = balance::split(coin::balance_mut(wallet), market.price);
         slot::pay(slot, funds, 1);
 
-        let certificate = slot::issue_nft_certificate_internal<
-            FixedPriceMarket<FT>, Witness
-        >(
+        slot::redeem_nft_and_transfer<C, FixedPriceMarket<FT>, Witness>(
             Witness {},
-            launchpad,
             slot,
             market_id,
-            ctx
-        );
-
-        transfer::transfer(
-            certificate,
             tx_context::sender(ctx),
         );
     }

--- a/sources/launchpad/market/fixed_price.move
+++ b/sources/launchpad/market/fixed_price.move
@@ -77,7 +77,7 @@ module nft_protocol::fixed_price {
     /// A `NftCertificate` object will be minted and transfered to the sender
     /// of transaction. The sender can then use this certificate to call
     /// `claim_nft` and claim the NFT that has been allocated by the slingshot
-    public entry fun buy_nft_certificate<C, FT>(
+    public entry fun buy_nft<C, FT>(
         slot: &mut Slot,
         market_id: ID,
         wallet: &mut Coin<FT>,

--- a/sources/launchpad/market/fixed_price.move
+++ b/sources/launchpad/market/fixed_price.move
@@ -16,13 +16,11 @@ module nft_protocol::fixed_price {
     // `buy_whitelisted_nft_certificate`
     use sui::balance;
     use sui::coin::{Self, Coin};
-    use sui::transfer::{Self};
     use sui::object::{Self, ID, UID};
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::inventory::{Self, Inventory};
     use nft_protocol::slot::{Self, Slot, WhitelistCertificate};
-    use nft_protocol::launchpad::Launchpad;
 
     struct FixedPriceMarket<phantom FT> has key, store {
         id: UID,
@@ -80,7 +78,6 @@ module nft_protocol::fixed_price {
     /// of transaction. The sender can then use this certificate to call
     /// `claim_nft` and claim the NFT that has been allocated by the slingshot
     public entry fun buy_nft_certificate<C, FT>(
-        launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
         wallet: &mut Coin<FT>,
@@ -89,7 +86,6 @@ module nft_protocol::fixed_price {
         slot::assert_market_is_not_whitelisted(slot, market_id);
 
         buy_nft_<C, FT>(
-            launchpad,
             slot,
             market_id,
             wallet,
@@ -104,7 +100,6 @@ module nft_protocol::fixed_price {
     /// of transaction. The sender can then use this certificate to call
     /// `claim_nft` and claim the NFT that has been allocated by the slingshot
     public entry fun buy_whitelisted_nft<C, FT>(
-        launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
         wallet: &mut Coin<FT>,
@@ -117,7 +112,6 @@ module nft_protocol::fixed_price {
         slot::burn_whitelist_certificate(whitelist_token);
 
         buy_nft_<C, FT>(
-            launchpad,
             slot,
             market_id,
             wallet,
@@ -126,7 +120,6 @@ module nft_protocol::fixed_price {
     }
 
     fun buy_nft_<C, FT>(
-        launchpad: &Launchpad,
         slot: &mut Slot,
         market_id: ID,
         wallet: &mut Coin<FT>,

--- a/sources/launchpad/slot.move
+++ b/sources/launchpad/slot.move
@@ -388,12 +388,8 @@ module nft_protocol::slot {
     ) {
         assert_slot_admin(slot, ctx);
 
-        let nft_id = object::id(&nft);
-
         let inventory = inventory_mut(slot, market_id);
-        inventory::register_nft_for_sale(inventory, nft_id);
-
-        dof::add(&mut slot.id, nft_id, nft);
+        inventory::deposit_nft(inventory, nft);
     }
 
     /// Toggle the Slot's `live` to `true` therefore making the NFT sale live

--- a/sources/launchpad/slot.move
+++ b/sources/launchpad/slot.move
@@ -27,113 +27,90 @@ module nft_protocol::slot {
     use nft_protocol::object_box::{Self as obox, ObjectBox};
     use nft_protocol::inventory::{Self, Inventory};
 
-    // === NftCertificate ===
+    // /// Issue `NftCertificate`
+    // ///
+    // /// Requires that sender is the `Slot` admin
+    // public fun issue_nft_certificate(
+    //     launchpad: &Launchpad,
+    //     slot: &mut Slot,
+    //     market_id: ID,
+    //     ctx: &mut TxContext,
+    // ): NftCertificate {
+    //     assert_slot_launchpad_match(launchpad, slot);
+    //     assert_slot_admin(slot, ctx);
 
-    /// This object acts as an intermediate step between the payment
-    /// and the transfer of the NFT. The user first has to call
-    /// `buy_nft_certificate` which mints and transfers the `NftCertificate` to
-    /// the user. This object will dictate which NFT will the user receive by
-    /// calling the endpoint `claim_nft`
-    struct NftCertificate has key, store {
-        id: UID,
-        /// `Launchpad` ID to which the `Slot` this certificate is assigned
-        ///
-        /// Intended for discoverability
-        launchpad_id: ID,
-        /// `Slot` ID to which the `Market` this certificate is assigned
-        ///
-        /// Intended for discoverability
-        slot_id: ID,
-        /// `Market` from which this certificate can withdraw an `Nft`
-        market_id: ID,
-        /// ID of the `Nft` which can be withdrawn using this certificate
-        nft_id: ID,
-    }
+    //     let inventory = inventory_mut(slot, market_id);
+    //     let nft_id = inventory::pop_nft_from_sale(inventory);
 
-    /// Issue `NftCertificate`
-    ///
-    /// Requires that sender is the `Slot` admin
-    public fun issue_nft_certificate(
-        launchpad: &Launchpad,
-        slot: &mut Slot,
-        market_id: ID,
-        ctx: &mut TxContext,
-    ): NftCertificate {
-        assert_slot_launchpad_match(launchpad, slot);
-        assert_slot_admin(slot, ctx);
+    //     NftCertificate {
+    //         id: object::new(ctx),
+    //         launchpad_id: object::id(launchpad),
+    //         slot_id: object::id(slot),
+    //         market_id,
+    //         nft_id,
+    //     }
+    // }
 
-        let inventory = inventory_mut(slot, market_id);
-        let nft_id = inventory::pop_nft_from_sale(inventory);
+    // /// Issue `NftCertificate`
+    // ///
+    // /// Does not require that sender is the `Slot` admin allowing markets to
+    // /// issue certificates.
+    // public fun issue_nft_certificate_internal<
+    //     Market: key + store,
+    //     Witness: drop
+    // >(
+    //     _witness: Witness,
+    //     launchpad: &Launchpad,
+    //     slot: &mut Slot,
+    //     market_id: ID,
+    //     ctx: &mut TxContext,
+    // ): NftCertificate {
+    //     assert_slot_launchpad_match(launchpad, slot);
 
-        NftCertificate {
-            id: object::new(ctx),
-            launchpad_id: object::id(launchpad),
-            slot_id: object::id(slot),
-            market_id,
-            nft_id,
-        }
-    }
+    //     utils::assert_same_module_as_witness<Market, Witness>();
+    //     assert_market<Market>(slot, market_id);
 
-    /// Issue `NftCertificate`
-    ///
-    /// Does not require that sender is the `Slot` admin allowing markets to
-    /// issue certificates.
-    public fun issue_nft_certificate_internal<
-        Market: key + store,
-        Witness: drop
-    >(
-        _witness: Witness,
-        launchpad: &Launchpad,
-        slot: &mut Slot,
-        market_id: ID,
-        ctx: &mut TxContext,
-    ): NftCertificate {
-        assert_slot_launchpad_match(launchpad, slot);
+    //     let inventory = inventory_mut(slot, market_id);
+    //     let nft_id = inventory::pop_nft_from_sale(inventory);
 
-        utils::assert_same_module_as_witness<Market, Witness>();
-        assert_market<Market>(slot, market_id);
+    //     NftCertificate {
+    //         id: object::new(ctx),
+    //         launchpad_id: object::id(launchpad),
+    //         slot_id: object::id(slot),
+    //         market_id,
+    //         nft_id,
+    //     }
+    // }
 
-        let inventory = inventory_mut(slot, market_id);
-        let nft_id = inventory::pop_nft_from_sale(inventory);
+    // public entry fun transfer_nft_certificate(
+    //     launchpad: &Launchpad,
+    //     slot: &mut Slot,
+    //     market_id: ID,
+    //     recipient: address,
+    //     ctx: &mut TxContext,
+    // ) {
+    //     let certificate = issue_nft_certificate(
+    //         launchpad,
+    //         slot,
+    //         market_id,
+    //         ctx,
+    //     );
+    //     transfer::transfer(certificate, recipient);
+    // }
 
-        NftCertificate {
-            id: object::new(ctx),
-            launchpad_id: object::id(launchpad),
-            slot_id: object::id(slot),
-            market_id,
-            nft_id,
-        }
-    }
+    // public fun burn_nft_certificate(
+    //     certificate: NftCertificate,
+    // ) {
+    //     let NftCertificate {
+    //         id,
+    //         launchpad_id: _,
+    //         slot_id: _,
+    //         market_id: _,
+    //         nft_id: _,
+    //     } = certificate;
 
-    public entry fun transfer_nft_certificate(
-        launchpad: &Launchpad,
-        slot: &mut Slot,
-        market_id: ID,
-        recipient: address,
-        ctx: &mut TxContext,
-    ) {
-        let certificate = issue_nft_certificate(
-            launchpad,
-            slot,
-            market_id,
-            ctx,
-        );
-        transfer::transfer(certificate, recipient);
-    }
-
-    public fun burn_nft_certificate(
-        certificate: NftCertificate,
-    ) {
-        let NftCertificate {
-            id,
-            launchpad_id: _,
-            slot_id: _,
-            market_id: _,
-            nft_id: _,
-        } = certificate;
-
-        object::delete(id);
-    }
+    //     object::delete(id);
+    // }
 
     // === WhitelistCertificate ===
 

--- a/tests/market/dutch_auction.move
+++ b/tests/market/dutch_auction.move
@@ -14,7 +14,7 @@ module nft_protocol::test_dutch_auction {
     use nft_protocol::nft;
     use nft_protocol::proceeds;
     use nft_protocol::inventory;
-    use nft_protocol::slot::{Self, NftCertificate, WhitelistCertificate, Slot};
+    use nft_protocol::slot::{Self, WhitelistCertificate, Slot};
     use nft_protocol::dutch_auction::{Self, DutchAuctionMarket};
 
     use nft_protocol::test_slot::init_slot;
@@ -65,7 +65,7 @@ module nft_protocol::test_dutch_auction {
         let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
-        
+
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
@@ -256,7 +256,7 @@ module nft_protocol::test_dutch_auction {
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let wallet = coin::mint_for_testing<SUI>(44, ctx(&mut scenario));
-        
+
         dutch_auction::create_bid(
             &mut wallet,
             &mut slot,
@@ -400,7 +400,7 @@ module nft_protocol::test_dutch_auction {
         slot::sale_on(&mut slot, ctx(&mut scenario));
 
         let wallet = coin::mint_for_testing<SUI>(44, ctx(&mut scenario));
-        
+
         dutch_auction::create_bid(
             &mut wallet,
             &mut slot,
@@ -533,7 +533,7 @@ module nft_protocol::test_dutch_auction {
 
         test_scenario::next_tx(&mut scenario, BUYER);
 
-        dutch_auction::sale_conclude<SUI>(
+        dutch_auction::sale_conclude<COLLECTION, SUI>(
             &launchpad,
             &mut slot,
             market_id,
@@ -551,7 +551,7 @@ module nft_protocol::test_dutch_auction {
         let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
-        
+
         slot::add_nft(
             &mut slot,
             market_id,
@@ -565,7 +565,7 @@ module nft_protocol::test_dutch_auction {
             nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
             ctx(&mut scenario)
         );
-        
+
         slot::sale_on(&mut slot, ctx(&mut scenario));
 
         let wallet = coin::mint_for_testing<SUI>(35, ctx(&mut scenario));
@@ -597,7 +597,7 @@ module nft_protocol::test_dutch_auction {
             ctx(&mut scenario),
         );
 
-        dutch_auction::sale_conclude<SUI>(
+        dutch_auction::sale_conclude<COLLECTION, SUI>(
             &launchpad,
             &mut slot,
             market_id,
@@ -608,21 +608,6 @@ module nft_protocol::test_dutch_auction {
 
         // Slot should be automatically turned off after concluding the auction
         assert!(!slot::is_live(&slot), 0);
-
-        // Check certificates
-
-        let certificate0 = test_scenario::take_from_address<NftCertificate>(
-            &mut scenario, CREATOR
-        );
-        slot::assert_nft_certificate_slot(object::id(&slot), &certificate0);
-        
-        let certificate1 = test_scenario::take_from_address<NftCertificate>(
-            &mut scenario, CREATOR
-        );
-        slot::assert_nft_certificate_slot(object::id(&slot), &certificate1);
-        
-        test_scenario::return_to_address(CREATOR, certificate0);
-        test_scenario::return_to_address(CREATOR, certificate1);
 
         // Check wallet balances
         assert!(coin::value(&wallet) == 2, 0);
@@ -664,7 +649,7 @@ module nft_protocol::test_dutch_auction {
         let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
-        
+
         slot::add_nft(
             &mut slot,
             market_id,
@@ -678,7 +663,7 @@ module nft_protocol::test_dutch_auction {
             nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
             ctx(&mut scenario)
         );
-        
+
         slot::sale_on(&mut slot, ctx(&mut scenario));
 
         let wallet = coin::mint_for_testing<SUI>(35, ctx(&mut scenario));
@@ -692,7 +677,7 @@ module nft_protocol::test_dutch_auction {
             ctx(&mut scenario),
         );
 
-        dutch_auction::sale_conclude<SUI>(
+        dutch_auction::sale_conclude<COLLECTION, SUI>(
             &launchpad,
             &mut slot,
             market_id,

--- a/tests/market/fixed_price.move
+++ b/tests/market/fixed_price.move
@@ -8,7 +8,7 @@ module nft_protocol::test_fixed_price {
 
     use nft_protocol::nft;
     use nft_protocol::inventory;
-    use nft_protocol::slot::{Self, Slot, NftCertificate, WhitelistCertificate};
+    use nft_protocol::slot::{Self, Slot, WhitelistCertificate};
     use nft_protocol::fixed_price::{Self, FixedPriceMarket};
 
     use nft_protocol::test_slot::init_slot;
@@ -59,10 +59,9 @@ module nft_protocol::test_fixed_price {
         let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
-        
+
         let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
-        fixed_price::buy_nft_certificate(
-            &launchpad,
+        fixed_price::buy_nft<COLLECTION, SUI>(
             &mut slot,
             market_id,
             &mut wallet,
@@ -83,10 +82,9 @@ module nft_protocol::test_fixed_price {
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
         slot::sale_on(&mut slot, ctx(&mut scenario));
-        
+
         let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
-        fixed_price::buy_nft_certificate(
-            &launchpad,
+        fixed_price::buy_nft<COLLECTION, SUI>(
             &mut slot,
             market_id,
             &mut wallet,
@@ -105,7 +103,7 @@ module nft_protocol::test_fixed_price {
         let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, false, &mut scenario);
-        
+
         slot::add_nft(
             &mut slot,
             market_id,
@@ -118,8 +116,7 @@ module nft_protocol::test_fixed_price {
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let wallet = coin::mint_for_testing<SUI>(15, ctx(&mut scenario));
-        fixed_price::buy_nft_certificate(
-            &launchpad,
+        fixed_price::buy_nft<COLLECTION, SUI>(
             &mut slot,
             market_id,
             &mut wallet,
@@ -130,12 +127,6 @@ module nft_protocol::test_fixed_price {
 
         transfer::transfer(wallet, BUYER);
         test_scenario::next_tx(&mut scenario, BUYER);
-
-        let certificate = test_scenario::take_from_address<NftCertificate>(
-            &mut scenario, BUYER
-        );
-        slot::assert_nft_certificate_slot(object::id(&slot), &certificate);
-        test_scenario::return_to_address(BUYER, certificate);
 
         test_scenario::return_shared(slot);
         test_scenario::return_shared(launchpad);
@@ -150,12 +141,11 @@ module nft_protocol::test_fixed_price {
 
         let market_id = init_market(&mut slot, 10, true, &mut scenario);
         slot::sale_on(&mut slot, ctx(&mut scenario));
-        
+
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
-        fixed_price::buy_nft_certificate(
-            &launchpad,
+        fixed_price::buy_nft<COLLECTION, SUI>(
             &mut slot,
             market_id,
             &mut wallet,
@@ -166,12 +156,6 @@ module nft_protocol::test_fixed_price {
 
         transfer::transfer(wallet, BUYER);
         test_scenario::next_tx(&mut scenario, BUYER);
-
-        let certificate = test_scenario::take_from_address<NftCertificate>(
-            &mut scenario, BUYER
-        );
-        slot::assert_nft_certificate_slot(object::id(&slot), &certificate);
-        test_scenario::return_to_address(BUYER, certificate);
 
         test_scenario::return_shared(slot);
         test_scenario::return_shared(launchpad);
@@ -184,14 +168,14 @@ module nft_protocol::test_fixed_price {
         let (launchpad, slot) = init_slot(CREATOR, &mut scenario);
 
         let market_id = init_market(&mut slot, 10, true, &mut scenario);
-        
+
         slot::add_nft(
             &mut slot,
             market_id,
             nft::new<COLLECTION>(CREATOR, ctx(&mut scenario)),
             ctx(&mut scenario)
         );
-        
+
         slot::sale_on(&mut slot, ctx(&mut scenario));
 
         slot::transfer_whitelist_certificate(
@@ -205,8 +189,7 @@ module nft_protocol::test_fixed_price {
         >(&scenario, BUYER);
 
         let wallet = coin::mint_for_testing<SUI>(10, ctx(&mut scenario));
-        fixed_price::buy_whitelisted_nft_certificate(
-            &launchpad,
+        fixed_price::buy_whitelisted_nft<COLLECTION, SUI>(
             &mut slot,
             market_id,
             &mut wallet,
@@ -216,12 +199,6 @@ module nft_protocol::test_fixed_price {
 
         transfer::transfer(wallet, BUYER);
         test_scenario::next_tx(&mut scenario, BUYER);
-
-        let certificate = test_scenario::take_from_address<NftCertificate>(
-            &mut scenario, BUYER
-        );
-        slot::assert_nft_certificate_slot(object::id(&slot), &certificate);
-        test_scenario::return_to_address(BUYER, certificate);
 
         test_scenario::return_shared(slot);
         test_scenario::return_shared(launchpad);

--- a/tests/mint_and_sell.move
+++ b/tests/mint_and_sell.move
@@ -141,7 +141,7 @@ module nft_protocol::mint_and_sell {
             ctx(&mut scenario),
         );
 
-        inventory::add_nft(&mut inventory, nft);
+        inventory::deposit_nft(&mut inventory, nft);
 
         // 4. Init Market in Launchpad Slot
         fixed_price::init_market_with_inventory<SUI>(


### PR DESCRIPTION
The intial purpose of NftCertificate was to allow the Launchpad to emit a certificate with an NFT ID, such that the user could then use this Certificate in a second function call to redeem the NFT with that ID. This had to be done because there were no Dynamic Fields before. Now, with the introduction of dynamic fields this two step process can be simplified to one step, and as a result, it improves the UX of the Marketplaces.