### PR TITLE
Feature: Composable NFTs

### DIFF
--- a/examples/tribal_realms.move
+++ b/examples/tribal_realms.move
@@ -1,0 +1,162 @@
+module nft_protocol::tribal_realms {
+    use std::string::{Self, String};
+
+    use sui::url;
+    use sui::balance;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    use nft_protocol::nft;
+    use nft_protocol::tags;
+    use nft_protocol::royalty;
+    use nft_protocol::display;
+    use nft_protocol::creators;
+    use nft_protocol::witness;
+    use nft_protocol::mint_cap::{MintCap};
+    use nft_protocol::warehouse::{Self, Warehouse};
+    use nft_protocol::composable_nft::{Self as c_nft};
+    use nft_protocol::royalties::{Self, TradePayment};
+    use nft_protocol::collection::{Self, Collection};
+
+    /// One time witness is only instantiated in the init method
+    struct TRIBAL_REALMS has drop {}
+
+    /// Types
+    struct Avatar has copy, drop, store {}
+    struct Skin has copy, drop, store {}
+    struct Hat has copy, drop, store {}
+    struct Glasses has copy, drop, store {}
+    struct Gun has copy, drop, store {}
+
+    /// Can be used for authorization of other actions post-creation. It is
+    /// vital that this struct is not freely given to any contract, because it
+    /// serves as an auth token.
+    struct Witness has drop {}
+
+    fun init(witness: TRIBAL_REALMS, ctx: &mut TxContext) {
+        let (mint_cap, collection) = collection::create(&witness, ctx);
+        let delegated_witness = witness::from_witness(&Witness {});
+
+        collection::add_domain(
+            delegated_witness,
+            &mut collection,
+            creators::from_address<TRIBAL_REALMS, Witness>(
+                &Witness {}, tx_context::sender(ctx), ctx,
+            ),
+        );
+
+        // Register custom domains
+        display::add_collection_display_domain(
+            delegated_witness,
+            &mut collection,
+            string::utf8(b"Suimarines"),
+            string::utf8(b"A unique NFT collection of Suimarines on Sui"),
+            ctx,
+        );
+
+        display::add_collection_url_domain(
+            delegated_witness,
+            &mut collection,
+            sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
+            ctx,
+        );
+
+        display::add_collection_symbol_domain(
+            delegated_witness,
+            &mut collection,
+            string::utf8(b"SUIM"),
+            ctx
+        );
+
+        let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
+        royalty::add_proportional_royalty(&mut royalty, 100);
+        royalty::add_royalty_domain(
+            delegated_witness,
+            &mut collection,
+            royalty,
+        );
+
+        let tags = tags::empty(ctx);
+        tags::add_tag(&mut tags, tags::art());
+        tags::add_collection_tag_domain(
+            delegated_witness,
+            &mut collection,
+            tags,
+        );
+
+        // Composability
+        let blueprint = c_nft::new_blueprint(ctx);
+        c_nft::add_parent_child_relationship<Avatar>(
+            &mut blueprint,
+            c_nft::new_child_node<Hat>(1, ctx), // limit, ctx
+            ctx
+        );
+        c_nft::add_parent_child_relationship<Avatar>(
+            &mut blueprint,
+            c_nft::new_child_node<Glasses>(1, ctx), // limit, ctx
+            ctx
+        );
+        c_nft::add_parent_child_relationship<Avatar>(
+            &mut blueprint,
+            c_nft::new_child_node<Gun>(1, ctx), // limit, ctx
+            ctx
+        );
+        c_nft::add_parent_child_relationship<Gun>(
+            &mut blueprint,
+            c_nft::new_child_node<Skin>(1, ctx), // limit, ctx
+            ctx
+        );
+
+        c_nft::add_blueprint_domain(delegated_witness, &mut collection, blueprint);
+
+        transfer::transfer(mint_cap, tx_context::sender(ctx));
+        transfer::share_object(collection);
+    }
+
+    /// Calculates and transfers royalties to the `RoyaltyDomain`
+    public entry fun collect_royalty<FT>(
+        payment: &mut TradePayment<TRIBAL_REALMS, FT>,
+        collection: &mut Collection<TRIBAL_REALMS>,
+        ctx: &mut TxContext,
+    ) {
+        let b = royalties::balance_mut(Witness {}, payment);
+
+        let domain = royalty::royalty_domain(collection);
+        let royalty_owed =
+            royalty::calculate_proportional_royalty(domain, balance::value(b));
+
+        royalty::collect_royalty(collection, b, royalty_owed);
+        royalties::transfer_remaining_to_beneficiary(Witness {}, payment, ctx);
+    }
+
+    public entry fun mint_nft<T: drop + store>(
+        name: String,
+        description: String,
+        url: vector<u8>,
+        attribute_keys: vector<String>,
+        attribute_values: vector<String>,
+        mint_cap: &MintCap<TRIBAL_REALMS>,
+        warehouse: &mut Warehouse<TRIBAL_REALMS>,
+        ctx: &mut TxContext,
+    ) {
+        let nft =
+            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = witness::from_witness(&Witness {});
+
+        display::add_display_domain(
+            delegated_witness, &mut nft, name, description, ctx,
+        );
+
+        display::add_url_domain(
+            delegated_witness, &mut nft, url::new_unsafe_from_bytes(url), ctx,
+        );
+
+        display::add_attributes_domain_from_vec(
+            delegated_witness, &mut nft, attribute_keys, attribute_values, ctx,
+        );
+
+        c_nft::add_type_domain<TRIBAL_REALMS, T>(delegated_witness, &mut nft, ctx);
+
+        warehouse::deposit_nft(warehouse, nft);
+    }
+}

--- a/examples/tribal_realms.move
+++ b/examples/tribal_realms.move
@@ -79,31 +79,34 @@ module nft_protocol::tribal_realms {
             tags,
         );
 
-        // Composability
-        let blueprint = c_nft::new_blueprint(ctx);
+        // === Avatar composability ===
+
+        let blueprint = c_nft::new_blueprint<Avatar>(ctx);
         c_nft::add_relationship<Avatar, Hat>(
             &mut blueprint,
             1, // limit
             1, // order
-            ctx
         );
         c_nft::add_relationship<Avatar, Glasses>(
             &mut blueprint,
             1, // limit
             1, // order
-            ctx
         );
         c_nft::add_relationship<Avatar, Gun>(
             &mut blueprint,
             1, // limit
             1, // order
-            ctx
         );
+
+        c_nft::add_blueprint_domain(delegated_witness, &mut collection, blueprint);
+
+        // === Gun composability ===
+
+        let blueprint = c_nft::new_blueprint<Gun>(ctx);
         c_nft::add_relationship<Gun, Skin>(
             &mut blueprint,
             1, // limit
             1, // order
-            ctx
         );
 
         c_nft::add_blueprint_domain(delegated_witness, &mut collection, blueprint);

--- a/examples/tribal_realms.move
+++ b/examples/tribal_realms.move
@@ -7,7 +7,6 @@ module nft_protocol::tribal_realms {
 
     use nft_protocol::nft;
     use nft_protocol::display;
-    use nft_protocol::witness;
     use nft_protocol::mint_cap::{MintCap};
     use nft_protocol::warehouse::{Self, Warehouse};
     use nft_protocol::composable_nft::{Self as c_nft};
@@ -30,7 +29,6 @@ module nft_protocol::tribal_realms {
 
     fun init(witness: TRIBAL_REALMS, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_collection_display_domain(
             &Witness {},
@@ -41,35 +39,39 @@ module nft_protocol::tribal_realms {
 
         // === Avatar composability ===
 
-        let blueprint = c_nft::new_blueprint<Avatar>(ctx);
+        let avatar_blueprint = c_nft::new_blueprint<Avatar>(ctx);
         c_nft::add_relationship<Avatar, Hat>(
-            &mut blueprint,
+            &mut avatar_blueprint,
             1, // limit
             1, // order
         );
         c_nft::add_relationship<Avatar, Glasses>(
-            &mut blueprint,
+            &mut avatar_blueprint,
             1, // limit
             1, // order
         );
         c_nft::add_relationship<Avatar, Gun>(
-            &mut blueprint,
+            &mut avatar_blueprint,
             1, // limit
             1, // order
         );
 
-        c_nft::add_blueprint_domain(delegated_witness, &mut collection, blueprint);
+        c_nft::add_blueprint_domain(
+            &Witness {}, &mut collection, avatar_blueprint,
+        );
 
         // === Gun composability ===
 
-        let blueprint = c_nft::new_blueprint<Gun>(ctx);
+        let gun_blueprint = c_nft::new_blueprint<Gun>(ctx);
         c_nft::add_relationship<Gun, Skin>(
-            &mut blueprint,
+            &mut gun_blueprint,
             1, // limit
             1, // order
         );
 
-        c_nft::add_blueprint_domain(delegated_witness, &mut collection, blueprint);
+        c_nft::add_blueprint_domain(
+            &Witness {}, &mut collection, gun_blueprint,
+        );
 
         transfer::transfer(mint_cap, tx_context::sender(ctx));
         transfer::share_object(collection);

--- a/examples/tribal_realms.move
+++ b/examples/tribal_realms.move
@@ -6,10 +6,7 @@ module nft_protocol::tribal_realms {
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::nft;
-    use nft_protocol::tags;
-    use nft_protocol::royalty;
     use nft_protocol::display;
-    use nft_protocol::creators;
     use nft_protocol::witness;
     use nft_protocol::mint_cap::{MintCap};
     use nft_protocol::warehouse::{Self, Warehouse};
@@ -35,48 +32,11 @@ module nft_protocol::tribal_realms {
         let (mint_cap, collection) = collection::create(&witness, ctx);
         let delegated_witness = witness::from_witness(&Witness {});
 
-        collection::add_domain(
-            delegated_witness,
-            &mut collection,
-            creators::from_address<TRIBAL_REALMS, Witness>(
-                &Witness {}, tx_context::sender(ctx),
-            ),
-        );
-
-        // Register custom domains
         display::add_collection_display_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
-            string::utf8(b"Suimarines"),
-            string::utf8(b"A unique NFT collection of Suimarines on Sui"),
-        );
-
-        display::add_collection_url_domain(
-            delegated_witness,
-            &mut collection,
-            sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
-        );
-
-        display::add_collection_symbol_domain(
-            delegated_witness,
-            &mut collection,
-            string::utf8(b"SUIM"),
-        );
-
-        let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
-        royalty::add_proportional_royalty(&mut royalty, 100);
-        royalty::add_royalty_domain(
-            delegated_witness,
-            &mut collection,
-            royalty,
-        );
-
-        let tags = tags::empty(ctx);
-        tags::add_tag(&mut tags, tags::art());
-        tags::add_collection_tag_domain(
-            delegated_witness,
-            &mut collection,
-            tags,
+            string::utf8(b"TribalRealms"),
+            string::utf8(b"A composable NFT collection on Sui"),
         );
 
         // === Avatar composability ===
@@ -125,18 +85,14 @@ module nft_protocol::tribal_realms {
     ) {
         let url = url::new_unsafe_from_bytes(url);
 
-        let nft = nft::from_mint_cap(
-            mint_cap, name, url, tx_context::sender(ctx), ctx,
+        let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
+
+        display::add_display_domain(&Witness {}, &mut nft, name, description);
+        display::add_url_domain(&Witness {}, &mut nft, url);
+
+        c_nft::add_type_domain<TRIBAL_REALMS, Witness, T>(
+            &Witness {}, &mut nft,
         );
-        let delegated_witness = witness::from_witness(&Witness {});
-
-        display::add_display_domain(
-            delegated_witness, &mut nft, name, description,
-        );
-
-        display::add_url_domain(delegated_witness, &mut nft, url);
-
-        c_nft::add_type_domain<TRIBAL_REALMS, T>(delegated_witness, &mut nft, ctx);
 
         warehouse::deposit_nft(warehouse, nft);
     }

--- a/sources/standards/composability/composable_nft.move
+++ b/sources/standards/composability/composable_nft.move
@@ -1,74 +1,80 @@
 module nft_protocol::composable_nft {
-    // TODO: Limit configurations (i.e. how many weapon NFTs can be attached to Avatar NFT)
-    // TODO: Grouping of types into taxonomies can make the structuring of the
-    // type system easier as it would more closely resemble the business logic.
-    // However we should do this without introducing any convulution to this module,
-    // and therefore this should be a higher-level abstraction exposed in a separate module
     // TODO: Ideally we would allow for multiple NFTs to be composed together in a single
     // transaction
     // TODO: some endpoint for reorder_children
-    use std::option;
     use std::type_name::{Self, TypeName};
 
     use sui::transfer;
     use sui::object::{Self, ID, UID};
     use sui::tx_context::{Self, TxContext};
-    use sui::object_table::{Self, ObjectTable};
     use sui::vec_map::{Self, VecMap};
 
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::collection::{Self, Collection};
     use nft_protocol::witness::Witness as DelegatedWitness;
+    use nft_protocol::nft_bag;
 
+    /// Parent and child types are not composable
+    ///
+    /// Call `composable_nft::add_relationship` to add parent child
+    /// relationship to the composability blueprint.
+    const ETYPES_NOT_COMPOSABLE: u64 = 1;
+
+    /// Relationship between provided parent and child types is already defined
+    const ERELATIONSHIP_ALREADY_DEFINED: u64 = 2;
+
+    /// Exceeded composed type limit when calling `composable_nft::compose`
+    ///
+    /// Set a higher type limit in the composability blueprint.
+    const EEXCEEDED_TYPE_LIMIT: u64 = 3;
+
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
-    /// === ChildNode ===
+    /// Internal struct for indexing NFTs in `NftBagDomain`
+    struct Key<phantom T> has drop, store {}
+
+    // === Node ===
 
     /// Defines the properties of a child NFT in the context of type-limited
     /// composability
-    struct ChildNode has store {
+    struct Node has store {
         // Amount of times the child NFT can be attached
         limit: u64,
-        // TODO: ChildNode generic about parametrization types
+        // TODO: Node generic about parametrization types
         // Rendering order of the child NFT
         order: u64,
     }
 
-    /// Create a new `ChildNode`
-    fun new_child_node(limit: u64, order: u64): ChildNode {
-        ChildNode { limit, order }
+    /// Create a new `Node`
+    fun new_child_node(limit: u64, order: u64): Node {
+        Node { limit, order }
     }
 
-    /// === Type ===
+    // === Type ===
 
-    struct Type<phantom T> has key, store {
-        id: UID,
+    /// NFT type market
+    struct Type<phantom T> has store {}
+
+    public fun new_type<T>(): Type<T> {
+        Type {}
     }
 
-    public fun new_type<T: drop + store>(
-        ctx: &mut TxContext,
-    ): Type<T> {
-        Type {
-            id: object::new(ctx),
-        }
-    }
-
-    public fun add_type_domain<C, T: drop + store>(
-        witness: DelegatedWitness<C>,
+    public fun add_type_domain<C, W, T>(
+        witness: &W,
         nft: &mut Nft<C>,
-        ctx: &mut TxContext
     ) {
-        nft::add_domain(witness, nft, new_type<T>(ctx));
+        nft::add_domain(witness, nft, new_type<T>());
     }
 
-    /// === Blueprint ===
+    // === Blueprint ===
 
     /// Domain held in the Collection object, blueprinting all the composability
     /// between types. It contains a ObjectTable with all the nodes of the
     /// composability flattened.
     struct Blueprint<phantom T> has store {
         id: UID,
-        nodes: VecMap<TypeName, ChildNode>,
+        nodes: VecMap<TypeName, Node>,
     }
 
     public fun new_blueprint<Parent>(ctx: &mut TxContext): Blueprint<Parent> {
@@ -88,24 +94,50 @@ module nft_protocol::composable_nft {
         limit: u64,
         order: u64,
     ) {
-        assert!(!has_child<Parent, Child>(blueprint), 0);
+        let child_type = type_name::get<Child>();
+
+        assert!(
+            !has_child<Parent>(blueprint, &child_type),
+            ERELATIONSHIP_ALREADY_DEFINED,
+        );
 
         let child = new_child_node(limit, order);
-        let child_type = type_name::get<Child>();
         vec_map::insert(&mut blueprint.nodes, child_type, child);
     }
 
+    /// Returns whether a parent child relationship exists in the blueprint
+    public fun has_child<Parent>(
+        blueprint: &Blueprint<Parent>,
+        child_type: &TypeName,
+    ): bool {
+        vec_map::contains(&blueprint.nodes, child_type)
+    }
+
+    /// Borrow child node from composability blueprint
+    ///
+    /// #### Panics
+    ///
+    /// Panics if parent child relationship was not defined on composability
+    /// blueprint.
     public fun borrow_child<Parent>(
         blueprint: &Blueprint<Parent>,
         child_type: &TypeName,
-    ): &ChildNode {
+    ): &Node {
+        assert_composable<Parent>(blueprint, child_type);
         vec_map::get(&blueprint.nodes, child_type)
     }
 
+    /// Mutbaly borrow child node from composability blueprint
+    ///
+    /// #### Panics
+    ///
+    /// Panics if parent child relationship was not defined on composability
+    /// blueprint.
     fun borrow_child_mut<Parent>(
         blueprint: &mut Blueprint<Parent>,
         child_type: &TypeName,
-    ): &mut ChildNode {
+    ): &mut Node {
+        assert_composable<Parent>(blueprint, child_type);
         vec_map::get_mut(&mut blueprint.nodes, child_type)
     }
 
@@ -115,72 +147,23 @@ module nft_protocol::composable_nft {
         collection: &mut Collection<C>,
         domain: Blueprint<Parent>,
     ) {
-        collection::add_domain(witness, collection, domain);
+        collection::add_domain_delegated(witness, collection, domain);
     }
 
-    /// === Nfts Domain ===
-
-    /// Domain to be owned by the parent Nft.
-    /// Allows the parent Nft to hold Child Nfts
-    struct Nfts<phantom C> has key, store {
-        id: UID,
-        // A 2-rank tensor represented by a 2-nested object vector, where
-        // the outer vector is indexed by object TypeName, and the inner vector
-        // is index.
-        // A nested structure is preferred over a simple ObjectTable as it
-        // reduces the amount of average iterations required in read/write
-        // operations
-        table: VecMap<TypeName, ObjectTable<ID, Nft<C>>>
-    }
-
-    /// Mutably borrow entry of children
-    ///
-    /// Creates a new entry if one does not already exist.
-    ///
-    /// Endpoint is unprotected and relies on safe access to `Nfts`.
-    public fun borrow_composed_mut<C>(
-        nfts: &mut Nfts<C>,
-        parent_type: &TypeName,
-        ctx: &mut TxContext,
-    ): &mut ObjectTable<ID, Nft<C>> {
-        let idx_opt = vec_map::get_idx_opt(&nfts.table, parent_type);
-
-        let idx = if (option::is_some(&idx_opt)) {
-            option::destroy_some(idx_opt)
-        } else {
-            let idx = vec_map::size(&nfts.table);
-            vec_map::insert(
-                &mut nfts.table,
-                *parent_type,
-                object_table::new<ID, Nft<C>>(ctx),
-            );
-            idx
-        };
-
-        let (_, entry) =
-            vec_map::get_entry_by_idx_mut(&mut nfts.table, idx);
-        entry
-    }
-
-    /// Mutably borrow entry of children
-    ///
-    /// Endpoint is unprotected and relies on safe access to `Nfts`.
+    /// Compose child NFT into parent NFT
     ///
     /// #### Panics
     ///
-    /// Panics if entry does not exist
-    public fun try_borrow_composed_mut<C>(
-        nfts: &mut Nfts<C>,
-        parent_type: &TypeName,
-    ): &mut ObjectTable<ID, Nft<C>> {
-        vec_map::get_mut(&mut nfts.table, parent_type)
-    }
-
+    /// * `Blueprint<Parent>` is not registered as a domain on the parent NFT
+    /// * Parent child relationship is not defined on the composability
+    /// blueprint
+    /// * Parent or child NFT do not have corresponding `Type<Parent>` and
+    /// `Type<Child>` domains registered
+    /// * Limit of children is exceeded
     public entry fun compose<C, Parent: store, Child: store>(
         parent_nft: &mut Nft<C>,
         child_nft: Nft<C>,
         collection: &Collection<C>,
-        ctx: &mut TxContext,
     ) {
         let blueprint: &Blueprint<Parent> =
             collection::borrow_domain(collection);
@@ -189,23 +172,18 @@ module nft_protocol::composable_nft {
         nft::assert_domain<C, Type<Parent>>(parent_nft);
         nft::assert_domain<C, Type<Child>>(&child_nft);
 
-        // Assert if Parent and Child are composable
-        assert!(has_child<Parent, Child>(blueprint), 0);
+        // Asserts that parent and child are composable
+        let child_type = type_name::get<Child>();
+        let node = borrow_child<Parent>(blueprint, &child_type);
 
-        let nfts = nft::borrow_domain_mut<C, Nfts<C>, Witness>(
-            Witness {}, parent_nft
+        let nfts = nft_bag::borrow_domain_mut(parent_nft);
+
+        assert!(
+            nft_bag::count<Key<Child>>(nfts) < node.limit,
+            EEXCEEDED_TYPE_LIMIT,
         );
 
-        let parent_type = type_name::get<Parent>();
-        let nft_vec = borrow_composed_mut(nfts, &parent_type, ctx);
-
-        // Asserts that type is composable
-        let child_type = type_name::get<Child>();
-        let child_node = borrow_child<Parent>(blueprint, &child_type);
-
-        assert!(object_table::length(nft_vec) <= child_node.limit, 0);
-
-        object_table::add(nft_vec, object::id(&child_nft), child_nft);
+        nft_bag::compose(Key<Child> {}, nfts, child_nft);
     }
 
     /// Decomposes NFT with given ID from parent NFT
@@ -216,42 +194,40 @@ module nft_protocol::composable_nft {
     public entry fun decompose<C, Parent, Child>(
         parent_nft: &mut Nft<C>,
         child_nft_id: ID,
+    ): Nft<C> {
+        let nfts = nft_bag::borrow_domain_mut(parent_nft);
+        nft_bag::decompose(Key<Child> {}, nfts, child_nft_id)
+    }
+
+    /// Decomposes NFT with given ID from parent NFT and transfers to
+    /// transaction sender
+    ///
+    /// #### Panics
+    ///
+    /// Panics if there is no NFT with given ID composed
+    public entry fun decompose_and_transfer<C, Parent, Child>(
+        parent_nft: &mut Nft<C>,
+        child_nft_id: ID,
         ctx: &mut TxContext,
     ) {
-        let nfts: &mut Nfts<C> =
-            nft::borrow_domain_mut(Witness {}, parent_nft);
-
-        let parent_type = type_name::get<Parent>();
-        let nft_vec = try_borrow_composed_mut(nfts, &parent_type);
-
-        // TODO: Remove object table if empty
-        let child_nft = object_table::remove(nft_vec, child_nft_id);
-
-        transfer::transfer(child_nft, tx_context::sender(ctx));
+        let nft = decompose<C, Parent, Child>(parent_nft, child_nft_id);
+        transfer::transfer(nft, tx_context::sender(ctx));
     }
 
-    public fun has_child<Parent, Child>(blueprint: &Blueprint<Parent>): bool {
-        let child_type = type_name::get<Child>();
-        vec_map::contains(&blueprint.nodes, &child_type)
-    }
+    // === Assertions ===
 
-    /// Creates new `Nfts` domain
-    public fun new_nfts_domain<C>(ctx: &mut TxContext): Nfts<C> {
-        Nfts {
-            id: object::new(ctx),
-            table: vec_map::empty(),
-        }
-    }
-
-    public fun nfts_domain<C>(nft: &Nft<C>): &Nfts<C> {
-        nft::borrow_domain(nft)
-    }
-
-    fun add_nfts_domain<C>(
-        witness: DelegatedWitness<C>,
-        nft: &mut Nft<C>,
-        ctx: &mut TxContext,
+    /// Assert that parent and child types are composable
+    ///
+    /// #### Panics
+    ///
+    /// Panics if parent and child types are not composable.
+    public fun assert_composable<Parent>(
+        blueprint: &Blueprint<Parent>,
+        child_type: &TypeName,
     ) {
-        nft::add_domain(witness, nft, new_nfts_domain<C>(ctx));
+        assert!(
+            has_child<Parent>(blueprint, child_type),
+            ETYPES_NOT_COMPOSABLE,
+        );
     }
 }

--- a/sources/standards/composability/composable_nft.move
+++ b/sources/standards/composability/composable_nft.move
@@ -1,0 +1,299 @@
+module nft_protocol::composable_nft {
+    // TODO: Limit configurations (i.e. how many weapon NFTs can be attached to Avatar NFT)
+    // TODO: Grouping of types into taxonomies can make the structuring of the
+    // type system easier as it would more closely resemble the business logic.
+    // However we should do this without introducing any convulution to this module,
+    // and therefore this should be a higher-level abstraction exposed in a separate module
+    // TODO: Ideally we would allow for multiple NFTs to be composed together in a single
+    // transaction
+    // TODO: some endpoint for reorder_children
+    use std::type_name::{Self, TypeName};
+
+    use sui::transfer;
+    use sui::object::{Self, ID, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::object_table::{Self, ObjectTable};
+
+    use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::collection::{Self, Collection};
+    use nft_protocol::witness::Witness as DelegatedWitness;
+
+    struct Witness has drop {}
+
+    /// ====== ChildNode ===
+
+    /// Defines a Child type in the context of a composability node.
+    /// To be used by ParentNode
+    struct ChildNode has key, store {
+        id: UID,
+        // Child type
+        type: TypeName,
+        // Amount of times child NFT of a the type given
+        // can be attached to a given Parent NFT
+        limit: u64,
+    }
+
+    public fun new_child_node<Child>(
+        limit: u64,
+        ctx: &mut TxContext,
+    ): ChildNode {
+        ChildNode {
+            id: object::new(ctx),
+            type: type_name::get<Child>(),
+            limit: limit,
+        }
+    }
+
+    /// ====== ParentNode ===
+
+    /// Defines which child NFTs can be attached to the Parent NFT.
+    struct ParentNode has key, store {
+        id: UID,
+        children: ObjectTable<TypeName, ChildNode>,
+    }
+
+    public fun new_parent_node(
+        ctx: &mut TxContext
+    ): ParentNode {
+        ParentNode {
+            id: object::new(ctx),
+            children: object_table::new(ctx),
+        }
+    }
+
+    public fun add_child(
+        parent_node: &mut ParentNode,
+        child: ChildNode,
+    ) {
+        object_table::add(&mut parent_node.children, child.type, child);
+    }
+
+    /// ====== Type ===
+
+    struct Type<phantom T> has key, store {
+        id: UID,
+    }
+
+    public fun new_type<T: drop + store>(
+        ctx: &mut TxContext,
+    ): Type<T> {
+        Type {
+            id: object::new(ctx),
+        }
+    }
+
+    public fun add_type_domain<C, T: drop + store>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        ctx: &mut TxContext
+    ) {
+        nft::add_domain(witness, nft, new_type<T>(ctx));
+    }
+
+    /// ====== Blueprint ===
+
+    /// Domain held in the Collection object, blueprinting all the composability
+    /// between types. It contains a ObjectTable with all the nodes of the
+    /// composability flattened.
+    struct Blueprint has key, store {
+        id: UID,
+        // ObjectTable with index TypeName as the type of the Parent,
+        // and the value as ParentNode which contains all the children info
+        nodes: ObjectTable<TypeName, ParentNode>,
+    }
+
+    public fun new_blueprint(
+        ctx: &mut TxContext
+    ): Blueprint {
+        Blueprint {
+            id: object::new(ctx),
+            nodes: object_table::new<TypeName, ParentNode>(ctx),
+        }
+    }
+
+    public entry fun add_parent_child_relationship<Parent: store>(
+        blueprint: &mut Blueprint,
+        child_node: ChildNode,
+        ctx: &mut TxContext,
+    ) {
+        let parent_type = type_name::get<Parent>();
+
+        let has_parent = object_table::contains(
+            &blueprint.nodes, parent_type
+        );
+
+        // If it doesn't have an ObjectVec yet for this type,
+        // then it needs to create one.
+        if (!has_parent) {
+            object_table::add(
+                &mut blueprint.nodes,
+                parent_type,
+                new_parent_node(ctx),
+            );
+        };
+
+        assert!(!has_child<Parent>(&child_node, blueprint), 0);
+
+        let parent_node = object_table::borrow_mut(
+            &mut blueprint.nodes, parent_type
+        );
+
+        add_child(parent_node, child_node);
+    }
+
+    /// Registers `Blueprint` on the given `Collection`
+    public fun add_blueprint_domain<C>(
+        witness: DelegatedWitness<C>,
+        collection: &mut Collection<C>,
+        domain: Blueprint,
+    ) {
+        collection::add_domain(witness, collection, domain);
+    }
+
+    /// ====== Nfts Domain ===
+
+    /// Domain to be owned by the parent Nft.
+    /// Allows the parent Nft to hold Child Nfts
+    struct Nfts<phantom T> has key, store {
+        id: UID,
+        // A 2-rank tensor represented by a 2-nested object vector, where
+        // the outer vector is indexed by object TypeName, and the inner vector
+        // is index.
+        // A nested structure is preferred over a simple ObjectTable as it
+        // reduces the amount of average iterations required in read/write
+        // operations
+        table: ObjectTable<TypeName, ObjectTable<ID, Nft<T>>>
+    }
+
+    public entry fun compose<T, Parent: store, Child: store>(
+        parent_nft: &mut Nft<T>,
+        child_nft: Nft<T>,
+        collection: &Collection<T>,
+        ctx: &mut TxContext,
+    ) {
+        let parent_type = type_name::get<Parent>();
+        let child_type = type_name::get<Child>();
+
+        let blueprint = collection::borrow_domain<T, Blueprint>(collection);
+
+        // Assert that types match NFTs
+        nft::assert_domain<T, Type<Parent>>(parent_nft);
+        nft::assert_domain<T, Type<Child>>(&child_nft);
+
+        // Assert if Parent and Child have link
+        assert!(has_child_with_type<Parent, Child>(blueprint), 0);
+
+        // Assert that it can compose within the limit
+        let parent_node = object_table::borrow(
+            &blueprint.nodes,
+            parent_type,
+        );
+
+        let child_node = object_table::borrow(
+            &parent_node.children,
+            child_type,
+        );
+
+        let nfts = nft::borrow_domain_mut<T, Nfts<T>, Witness>(
+            Witness {}, parent_nft
+        );
+
+        // Add ObjectVec<Nft<T>> to Nfts<T> if not there
+        let has_type = object_table::contains(
+            &nfts.table, type_name::get<Child>()
+        );
+
+        // If there is no ObjectTable for this type, then it needs
+        // to create one.
+        if (!has_type) {
+            object_table::add(
+                &mut nfts.table,
+                type_name::get<Child>(),
+                object_table::new<ID, Nft<T>>(ctx)
+            );
+        };
+
+        let nft_vec = object_table::borrow_mut(&mut nfts.table, child_type);
+
+        // Assert that composition is within the limits
+        assert!(
+            object_table::length(nft_vec) <= child_node.limit,
+            0
+        );
+
+        object_table::add(nft_vec, object::id(&child_nft), child_nft);
+    }
+
+    public entry fun decompose<T, Child: store>(
+        parent_nft: &mut Nft<T>,
+        child_nft: &Nft<T>,
+        ctx: &mut TxContext,
+    ) {
+        // Confirm that child NFT is of type `Child`
+        nft::assert_domain<T, Type<Child>>(child_nft);
+        let child_nft_id = object::id(child_nft);
+
+        let child_type = type_name::get<Child>();
+        let nfts = nft::borrow_domain_mut<T, Nfts<T>, Witness>(Witness {}, parent_nft);
+
+        let nfts_of_child_type = object_table::borrow_mut<TypeName, ObjectTable<ID, Nft<T>>>(
+            &mut nfts.table,
+            child_type
+        );
+
+        // TODO: Remove object table if empty
+        let child_nft = object_table::remove<ID, Nft<T>>(nfts_of_child_type, child_nft_id);
+
+        transfer::transfer(child_nft, tx_context::sender(ctx));
+    }
+
+    public fun has_child<Parent: store>(
+        child: &ChildNode,
+        blueprint: &Blueprint,
+    ): bool {
+        let parent_type = type_name::get<Parent>();
+
+        let parent_node = object_table::borrow(
+            &blueprint.nodes, parent_type
+        );
+
+        object_table::contains(&parent_node.children, child.type)
+    }
+
+    public fun has_child_with_type<Parent: store, Child: store>(
+        blueprint: &Blueprint,
+    ): bool {
+        let parent_type = type_name::get<Parent>();
+        let child_type = type_name::get<Parent>();
+
+        let parent_node = object_table::borrow(
+            &blueprint.nodes, parent_type
+        );
+
+        object_table::contains(&parent_node.children, child_type)
+    }
+
+    /// Creates a new `Nfts` with name and description
+    public fun new_nfts_domain<C>(
+        ctx: &mut TxContext,
+    ): Nfts<C> {
+        Nfts<C> {
+            id: object::new(ctx),
+            table: object_table::new(ctx),
+        }
+    }
+
+    public fun nfts_domain<C>(
+        nft: &Nft<C>,
+    ): &Nfts<C> {
+        nft::borrow_domain(nft)
+    }
+
+    fun add_nfts_domain<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        ctx: &mut TxContext,
+    ) {
+        nft::add_domain(witness, nft, new_nfts_domain<C>(ctx));
+    }
+}


### PR DESCRIPTION
The cNFT feature should have the following specifications:

1. Creators should be able to define different Nft types within their collections (e.g. `Avatar`, `Weapon`, `Hat`, etc.)
2. Creators should be able to define how NFTs from different types compose with each other:
        - What is the maximum amount of numbers a NFT type can attach to another
        - What is the redenring order of the pictures?
        
In relation to the rendering order there are essentially two ways in which we can render composable NFTs:
1- The rendering occurs dynamically and facilitated by the client who reads urls and stacks pictures on top of each other
2- The rendering of the stack images occurts preemptively and it is dynamically loaded to IPFS or any other storage service and compose time. (This later requires an off-chain service to compose NFTs and needs to have the dedicated authority to push a new url to the NFT whenever a merge happens.