### PR TITLE
RoyaltyDomain refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Refactored RoyaltyDomain and CreatorsDomain to split royalty share and authorization logic.
 
 ## [0.17.0] - 2022-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## Unreleased
 
 - Refactored RoyaltyDomain and CreatorsDomain to split royalty share and authorization logic.
+- Added entry function redeem_nft_transfer thus allowing creators to retrieve NFTs from private `Inventory`.
 
 ## [0.17.0] - 2022-12-19
 

--- a/examples/football.move
+++ b/examples/football.move
@@ -53,11 +53,8 @@ module nft_protocol::football {
             string::utf8(b"FOOT")
         );
 
-        let royalty = royalty::new(ctx);
-        royalty::add_proportional_royalty(
-            &mut royalty,
-            nft_protocol::royalty_strategy_bps::new(100),
-        );
+        let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
+        royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(&mut collection, &mint_cap, royalty);
 
         let tags = tags::empty(ctx);

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -54,11 +54,8 @@ module nft_protocol::suimarines {
             string::utf8(b"SUIM")
         );
 
-        let royalty = royalty::new(ctx);
-        royalty::add_proportional_royalty(
-            &mut royalty,
-            nft_protocol::royalty_strategy_bps::new(100),
-        );
+        let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
+        royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(&mut collection, &mut mint_cap, royalty);
 
         let tags = tags::empty(ctx);

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -54,11 +54,8 @@ module nft_protocol::suitraders {
             string::utf8(b"SUITR")
         );
 
-        let royalty = royalty::new(ctx);
-        royalty::add_proportional_royalty(
-            &mut royalty,
-            nft_protocol::royalty_strategy_bps::new(100),
-        );
+        let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
+        royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(&mut collection, &mut mint_cap, royalty);
 
         let tags = tags::empty(ctx);

--- a/sources/launchpad/inventory.move
+++ b/sources/launchpad/inventory.move
@@ -120,6 +120,24 @@ module nft_protocol::inventory {
         dof::remove(&mut inventory.id, vector::pop_back(nfts))
     }
 
+    /// Redeems NFT from `Inventory` and transfers to sender
+    ///
+    /// Endpoint is unprotected and relies on safely obtaining a mutable
+    /// reference to `Inventory`.
+    ///
+    /// ##### Usage
+    ///
+    /// Entry mint functions like `suimarines::mint_nft` take an `Inventory`
+    /// object to deposit into. Calling `redeem_nft_transfer` allows one to
+    /// withdraw an NFT and own it directly.
+    public entry fun redeem_nft_transfer<C>(
+        inventory: &mut Inventory,
+        ctx: &mut TxContext,
+    ) {
+        let nft = redeem_nft<C>(inventory);
+        transfer::transfer(nft, tx_context::sender(ctx));
+    }
+
     /// Set market's live status
     public entry fun set_live(
         inventory: &mut Inventory,

--- a/sources/launchpad/market/dutch_auction.move
+++ b/sources/launchpad/market/dutch_auction.move
@@ -46,6 +46,7 @@ module nft_protocol::dutch_auction {
         owner: address,
     }
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     // === Init functions ===

--- a/sources/launchpad/market/fixed_price.move
+++ b/sources/launchpad/market/fixed_price.move
@@ -25,6 +25,7 @@ module nft_protocol::fixed_price {
         price: u64,
     }
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     // === Init functions ===

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -65,13 +65,13 @@ module nft_protocol::nft {
     /// fun init(witness: SUIMARINES, ctx: &mut TxContext) {
     ///     let nft = nft::new(&witness, tx_context::sender(ctx), ctx);
     /// }
+    /// ```
     ///
     /// ##### Panics
     ///
     /// Panics when attempting to create an NFT with a witness type originating
     /// from a different module than the one-time collection witness `C`. See
     /// [borrow_domain_mut](#borrow_domain_mut).
-    /// ```
     public fun new<C, W>(
         _witness: &W,
         owner: address,

--- a/sources/standards/creators.move
+++ b/sources/standards/creators.move
@@ -1,52 +1,15 @@
 /// Module of Collection `CreatorsDomain`
 ///
-/// `CreatorsDomain` tracks all collection creators, their respective
-/// addresses, as well as their royalty share.
-///
-/// `CreatorsDomain` is used to authenticate mutable operations on other
-/// OriginByte standard domains.
+/// `CreatorsDomain` tracks all collection creators, used to authenticate
+/// mutable operations on other OriginByte standard domains.
 module nft_protocol::creators {
-    use std::fixed_point32;
-
-    use sui::coin;
-    use sui::transfer;
-    use sui::vec_map::{Self, VecMap};
-    use sui::balance::{Self, Balance};
+    use sui::vec_set::{Self, VecSet};
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::err;
     use nft_protocol::collection::{Self, Collection, MintCap};
 
-    // === Creator ===
-
-    /// `Creator` type which holds the address of the `Collection` creator as
-    /// well their share of the royalties.
-    struct Creator has store, copy, drop {
-        who: address,
-        share_of_royalty_bps: u16,
-    }
-
-    /// Create new `Creator`
-    public fun new_creator(who: address, share_of_royalty_bps: u16): Creator {
-        Creator { who, share_of_royalty_bps }
-    }
-
-    /// Returns the address belonging to the `Creator`
-    public fun who(creator: &Creator): address {
-        creator.who
-    }
-
-    /// Returns the royalty share of the `Creator` in basis points
-    public fun share_of_royalty_bps(creator: &Creator): u16 {
-        creator.share_of_royalty_bps
-    }
-
-    /// === CreatorsDomain ===
-
-    const BPS: u16 = 10_000;
-
-    /// `CreatorsDomain` tracks collection creators, their respective
-    /// addresses, as well as their royalty share.
+    /// `CreatorsDomain` tracks collection creators
     ///
     /// ##### Usage
     ///
@@ -86,49 +49,41 @@ module nft_protocol::creators {
     struct CreatorsDomain has copy, drop, store {
         /// Frozen `CreatorsDomain` will no longer authenticate creators
         is_frozen: bool,
-        /// Creators that receive the mint and trade royalties
-        creators: VecMap<address, Creator>,
+        /// Creators that have the ability to mutate standard domains
+        creators: VecSet<address>,
     }
 
     /// Creates an empty `CreatorsDomain` object
     ///
-    /// By not attributing any `Creators`, nobody will ever be able to claim
-    /// royalties from this `CreatorsDomain` object or modify the `Collection`
-    /// domains.
-    public fun empty(): CreatorsDomain {
-        CreatorsDomain { is_frozen: false, creators: vec_map::empty() }
+    /// By not attributing any `Creators`, nobody will ever be able to modify
+    /// `Collection` domains.
+    public fun new_empty(): CreatorsDomain {
+        from_creators(vec_set::empty())
     }
 
     /// Creates a `CreatorsDomain` object with only one creator
     ///
-    /// Only the single `Creator` will ever be able to claim royalties from
-    /// this `CreatorsDomain` object and modify the `Collection` domains.
+    /// Only the single `Creator` will ever be able to modify `Collection`
+    /// domains.
     public fun from_address(who: address): CreatorsDomain {
-        let domain = empty();
-        vec_map::insert(&mut domain.creators, who, new_creator(who, BPS));
-        domain
+        let creators = vec_set::empty();
+        vec_set::insert(&mut creators, who);
+
+        from_creators(creators)
     }
 
     /// Creates a `CreatorsDomain` with multiple creators
     ///
-    /// Creators will be able to claim royalties and modify `Collection`
-    /// domains.
-    ///
-    /// ##### Panics
-    ///
-    /// Panics if total sum of creator basis point share is not equal to 10000.
-    public fun from_creators(
-        creators: VecMap<address, Creator>
-    ): CreatorsDomain {
-        let domain = CreatorsDomain { is_frozen: false, creators };
-        assert_total_shares(&domain);
-
-        domain
+    /// Each attributed creator will be able to modify `Collection` domains.
+    public fun from_creators(creators: VecSet<address>): CreatorsDomain {
+        CreatorsDomain { is_frozen: false, creators }
     }
 
-    /// Returns whether `CreatorsDomain` has defined any creators
+    // === Getters ===
+
+    /// Returns whether `CreatorsDomain` has no defined creators
     public fun is_empty(domain: &CreatorsDomain): bool {
-        vec_map::is_empty(&domain.creators)
+        vec_set::is_empty(&domain.creators)
     }
 
     /// Returns whether `CreatorsDomain` is frozen
@@ -136,108 +91,17 @@ module nft_protocol::creators {
         domain.is_frozen
     }
 
+    /// Returns whether address is a defined creator
+    public fun contains_creator(domain: &CreatorsDomain, who: &address): bool {
+        vec_set::contains(&domain.creators, who)
+    }
+
     /// Returns the list of creators defined on the `CreatorsDomain`
-    public fun creators(
-        domain: &CreatorsDomain
-    ): &VecMap<address, Creator> {
+    public fun borrow_creators(domain: &CreatorsDomain): &VecSet<address> {
         &domain.creators
     }
 
-    /// Returns the `Creator` type for the given address
-    ///
-    /// ##### Panics
-    ///
-    /// Panics if the provided address is not an attributed creator
-    public fun get(
-        domain: &CreatorsDomain,
-        who: &address,
-    ): &Creator {
-        assert!(
-            vec_map::contains(&domain.creators, who),
-            err::address_not_attributed()
-        );
-        vec_map::get(&domain.creators, who)
-    }
-
-    /// Returns a mutable reference to the `Creator` type for the given address
-    ///
-    /// ##### Panics
-    ///
-    /// Panics if the provided address is not an attributed creator
-    fun get_mut(
-        domain: &mut CreatorsDomain,
-        who: address,
-    ): &mut Creator {
-        assert!(
-            vec_map::contains(&domain.creators, &who),
-            err::address_not_attributed()
-        );
-        vec_map::get_mut(&mut domain.creators, &who)
-    }
-
     // === Mutability ===
-
-    /// Add a `Creator` to `CreatorsDomain` object
-    ///
-    /// This must be done by a creator which already has an attribution who
-    /// gives up their share of the royalties for the benefit of the new
-    /// creator.
-    ///
-    /// ##### Panics
-    ///
-    /// Panics if the transaction sender does not have a large enough royalty
-    /// share to transfer to the new creator.
-    public fun add_creator(
-        domain: &mut CreatorsDomain,
-        new_creator: Creator,
-        ctx: &mut TxContext,
-    ) {
-        // Asserts that sender is a creator
-        let creator = get_mut(domain, tx_context::sender(ctx));
-
-        assert!(
-            creator.share_of_royalty_bps >= new_creator.share_of_royalty_bps,
-            err::address_does_not_have_enough_shares()
-        );
-
-        creator.share_of_royalty_bps =
-            creator.share_of_royalty_bps - new_creator.share_of_royalty_bps;
-
-        if (creator.share_of_royalty_bps == 0) {
-            let who = creator.who;
-            vec_map::remove(&mut domain.creators, &who);
-        };
-
-        vec_map::insert(&mut domain.creators, new_creator.who, new_creator);
-    }
-
-    /// Remove a `Creator` from CreatorsDomain
-    ///
-    /// Creators can only remove themselves. Shares of removed `Creator` are
-    /// allocated to the provided address, who also must be a `Creator`.
-    ///
-    /// If the only `Creator` is removed then nobody will ever be able to claim
-    /// royalties in the future again.
-    //
-    // TODO: Create removal methods which split shares evenly and
-    // proportionally.
-    public fun remove_creator_by_transfer(
-        domain: &mut CreatorsDomain,
-        to: address,
-        ctx: &mut TxContext,
-    ) {
-        // Asserts that sender is a creator
-        let (_, creator) = vec_map::remove(
-            &mut domain.creators,
-            &tx_context::sender(ctx)
-        );
-
-        // Get creator to which shares will be transfered
-        let beneficiary = get_mut(domain, to);
-
-        beneficiary.share_of_royalty_bps =
-            beneficiary.share_of_royalty_bps + creator.share_of_royalty_bps;
-    }
 
     /// Makes `Collection` domains immutable
     ///
@@ -250,75 +114,15 @@ module nft_protocol::creators {
         domain.is_frozen = true
     }
 
-    /// Distributes the contents of a `Balance<FT>` among the creators defined
-    /// in the `CreatorsDomain`.
-    public fun distribute_balance<FT>(
-        domain: &CreatorsDomain,
-        aggregate: &mut Balance<FT>,
-        ctx: &mut TxContext,
-    ) {
-        // balance * share_of_royalty_bps / BPS
-        let total = fixed_point32::create_from_rational(
-            balance::value(aggregate),
-            (BPS as u64)
-        );
-
-        let i = 0;
-        while (i < vec_map::size(&domain.creators)) {
-            let (_, creator) =
-                vec_map::get_entry_by_idx(&domain.creators, i);
-
-            // Truncates fractional part of the result thus ensuring that sum
-            // of royalty shares is not greater than total balance.
-            let owed_royalty = fixed_point32::multiply_u64(
-                (creator.share_of_royalty_bps as u64),
-                total,
-            );
-
-            if (owed_royalty != 0) {
-                let wallet = coin::from_balance(
-                    balance::split(aggregate, owed_royalty),
-                    ctx,
-                );
-
-                transfer::transfer(wallet, creator.who);
-            };
-
-            i = i + 1;
-        };
-    }
-
     // === Utils ===
-
-    /// Asserts that total `Creator` shares add up to 10000 basis points
-    ///
-    /// ##### Panics
-    ///
-    /// Panics if shares do not add up to 10000 basis points
-    fun assert_total_shares(domain: &CreatorsDomain) {
-        let bps_total = 0;
-
-        let i = 0;
-        while (i < vec_map::size(&domain.creators)) {
-            let (_, creator) =
-                vec_map::get_entry_by_idx(&domain.creators, i);
-            bps_total = bps_total + creator.share_of_royalty_bps;
-            i = i + 1;
-        };
-
-        assert!(bps_total == BPS, err::invalid_total_share_of_royalties());
-    }
 
     /// Asserts that address is a `Creator` attributed in `CreatorsDomain`
     ///
     /// ##### Panics
     ///
     /// Panics if address is not an attribtued creator.
-    public fun assert_is_creator(
-        domain: &CreatorsDomain,
-        who: address
-    ) {
-        get(domain, &who);
+    public fun assert_is_creator(domain: &CreatorsDomain, who: &address) {
+        assert!(contains_creator(domain, who), err::address_not_attributed());
     }
 
     /// Asserts that address is a `Creator` attributed in `CreatorsDomain` of
@@ -330,13 +134,14 @@ module nft_protocol::creators {
     /// attributed creator.
     public fun assert_collection_has_creator<C>(
         collection: &Collection<C>,
-        who: address
+        who: &address
     ) {
         assert_is_creator(creators_domain(collection), who);
     }
 
-    /// ====== Interoperability ===
+    // ====== Interoperability ===
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     /// Borrows `CreatorsDomain` from `Collection`
@@ -363,7 +168,7 @@ module nft_protocol::creators {
         ctx: &mut TxContext,
     ): &mut CreatorsDomain {
         assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         collection::borrow_domain_mut(Witness {}, collection)

--- a/sources/standards/creators.move
+++ b/sources/standards/creators.move
@@ -178,8 +178,8 @@ module nft_protocol::creators {
     ///
     /// ##### Panics
     ///
-    /// Panics if `MintCap` does not match `Collection` or domain `D` already
-    /// exists.
+    /// Panics if `MintCap` does not match `Collection` or `CreatorsDomain`
+    /// already exists.
     public fun add_creators_domain<C>(
         collection: &mut Collection<C>,
         mint_cap: &mut MintCap<C>,

--- a/sources/standards/display.move
+++ b/sources/standards/display.move
@@ -18,6 +18,7 @@ module nft_protocol::display {
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::collection::{Self, Collection, MintCap};
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     struct DisplayDomain has store {
@@ -52,7 +53,7 @@ module nft_protocol::display {
         ctx: &mut TxContext,
     ) {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         let domain: &mut DisplayDomain =
@@ -70,7 +71,7 @@ module nft_protocol::display {
         ctx: &mut TxContext,
     ) {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         let domain: &mut DisplayDomain =
@@ -79,7 +80,7 @@ module nft_protocol::display {
         domain.description = description;
     }
 
-    /// ====== Interoperability ===
+    // ====== Interoperability ===
 
     public fun display_domain<C>(
         nft: &Nft<C>,
@@ -113,7 +114,7 @@ module nft_protocol::display {
         );
     }
 
-    /// === UrlDomain ===
+    // === UrlDomain ===
 
     struct UrlDomain has store {
         url: Url,
@@ -138,7 +139,7 @@ module nft_protocol::display {
         ctx: &mut TxContext,
     ) {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         let domain: &mut UrlDomain =
@@ -147,7 +148,7 @@ module nft_protocol::display {
         domain.url = url;
     }
 
-    /// ====== Interoperability ===
+    // ====== Interoperability ===
 
     public fun display_url<C>(nft: &Nft<C>): Option<Url> {
         if (!nft::has_domain<C, UrlDomain>(nft)) {
@@ -181,7 +182,7 @@ module nft_protocol::display {
         collection::add_domain(nft, mint_cap, new_url_domain(url));
     }
 
-    /// === SymbolDomain ===
+    // === SymbolDomain ===
 
     struct SymbolDomain has store {
         symbol: String,
@@ -206,7 +207,7 @@ module nft_protocol::display {
         ctx: &mut TxContext,
     ) {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         let domain: &mut SymbolDomain =
@@ -215,7 +216,7 @@ module nft_protocol::display {
         domain.symbol = symbol;
     }
 
-    /// ====== Interoperability ===
+    // ====== Interoperability ===
 
     public fun display_symbol<C>(nft: &Nft<C>): Option<String> {
         if (!nft::has_domain<C, SymbolDomain>(nft)) {
@@ -251,7 +252,7 @@ module nft_protocol::display {
         collection::add_domain(nft, mint_cap, new_symbol_domain(symbol));
     }
 
-    /// === AttributesDomain ===
+    // === AttributesDomain ===
 
     struct AttributesDomain has store {
         map: VecMap<String, String>,
@@ -281,7 +282,7 @@ module nft_protocol::display {
         AttributesDomain { map }
     }
 
-    /// ====== Interoperability ===
+    // ====== Interoperability ===
 
     public fun display_attribute<C>(nft: &Nft<C>): &AttributesDomain {
         nft::borrow_domain<C, AttributesDomain>(nft)
@@ -293,7 +294,7 @@ module nft_protocol::display {
         ctx: &mut TxContext,
     ): &mut AttributesDomain {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
         nft::borrow_domain_mut<C, AttributesDomain, Witness>(Witness {}, nft)
     }

--- a/sources/standards/royalties/royalty.move
+++ b/sources/standards/royalties/royalty.move
@@ -1,15 +1,26 @@
-/// Module of Collection `Royalty` domain.
+/// Module of Collection `RoyaltyDomain`
 ///
-/// It allows Creators to define a royalty strategy for their collections.
-/// It exposes public functions to be used by the Type-exporting `C`ollection
-/// type module (e.g. Suimarines) in order to calculate the royalty given a
-/// amount. This module relies on the type-exporting module as an
-/// oracle for the execution price of the trade.
+/// `RoyaltyDomain` allows creators to define custom royalty strategies,
+/// collect royalties for their collections. Additionally, creators and their
+/// respective royalty share are tracked.
+///
+/// `royalty` does not provide a generic `calculate` function that takes into
+/// account all royalty strategies defined on the domain, as the OriginByte
+/// standard does not know how to read strategies not otherwise defined by it.
+///
+/// The module relies on an external contract to drive the royalty gathering
+/// and dirtribution flow.
 module nft_protocol::royalty {
+    use std::fixed_point32;
+
+    use sui::coin;
+    use sui::transfer;
     use sui::balance::{Self, Balance};
     use sui::tx_context::{Self, TxContext};
     use sui::bag::{Self, Bag};
+    use sui::vec_map::{Self, VecMap};
 
+    use nft_protocol::err;
     use nft_protocol::utils::{Self, Marker};
     use nft_protocol::creators;
     use nft_protocol::royalty_strategy_bps::{Self, BpsRoyaltyStrategy};
@@ -18,25 +29,207 @@ module nft_protocol::royalty {
         Self, ConstantRoyaltyStrategy
     };
 
+    const BPS: u16 = 10_000;
+
+    // === RoyaltyDomain ===
+
+    /// `RoyaltyDomain` stores royalty strategies for `Collection` and
+    /// distributes them among creators
+    ///
+    /// ##### Usage
+    ///
+    /// `RoyaltyDomain` can only calculate royalties owed and distribute them
+    /// to shareholders, but relies on a trusted execution price oracle.
+    ///
+    /// The usage example shows how to derive the owed royalties from the
+    /// example sollection, `Suimarines`, which uses `TradePayment` as the
+    /// price oracle, but is also responsible for deconstructing it. For more
+    /// information read [royalties](./royalties.html).
+    ///
+    /// ```
+    /// module nft_protocol::suimarines {
+    ///     struct Witness has drop {}
+    ///
+    ///     public entry fun collect_royalty<FT>(
+    ///         payment: &mut TradePayment<SUIMARINES, FT>,
+    ///         collection: &mut Collection<SUIMARINES>,
+    ///         ctx: &mut TxContext,
+    ///     ) {
+    ///         let b = royalties::balance_mut(Witness {}, payment);
+    ///
+    ///         let domain = royalty::royalty_domain(collection);
+    ///         let royalty_owed =
+    ///             royalty::calculate_proportional_royalty(domain, balance::value(b));
+    ///
+    ///         royalty::collect_royalty(collection, b, royalty_owed);
+    ///         royalties::transfer_remaining_to_beneficiary(Witness {}, payment, ctx);
+    ///     }
+    /// }
+    /// ```
     struct RoyaltyDomain has store {
         /// Royalty strategies
         strategies: Bag,
         /// Aggregates received royalties across different coins
         aggregations: Bag,
+        /// Royalty share received by addresses
+        royalty_shares_bps: VecMap<address, u16>,
     }
 
-    /// Creates a `RoyaltyDomain` object with a single creator creators.
-    public fun new(ctx: &mut TxContext): RoyaltyDomain {
+    /// Creates an empty `RoyaltyDomain` object
+    ///
+    /// By not attributing any addresses, nobody will ever be able to claim
+    /// royalties from this `RoyaltyDomain` object.
+    public fun new_empty(ctx: &mut TxContext): RoyaltyDomain {
+        from_shares(vec_map::empty(), ctx)
+    }
+
+    /// Creates a `RoyaltyDomain` object with only one creator
+    ///
+    /// Only the single address will be able to claim royalties from this
+    /// `RoyaltyDomain` object and modify the `Collection` domains.
+    public fun from_address(who: address, ctx: &mut TxContext): RoyaltyDomain {
+        let shares = vec_map::empty();
+        vec_map::insert(&mut shares, who, BPS);
+
+        from_shares(shares, ctx)
+    }
+
+    /// Creates a `RoyaltyDomain` with multiple creators
+    ///
+    /// Creators will be able to claim royalties and modify `Collection`
+    /// domains.
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if total sum of creator basis point share is not equal to 10000
+    public fun from_shares(
+        royalty_shares_bps: VecMap<address, u16>,
+        ctx: &mut TxContext,
+    ): RoyaltyDomain {
+        assert_total_shares(&royalty_shares_bps);
         RoyaltyDomain {
             strategies: bag::new(ctx),
             aggregations: bag::new(ctx),
+            royalty_shares_bps,
         }
+    }
+
+    // === Shares ===
+
+    /// Returns the `Creator` type for the given address
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if the provided address is not an attributed creator
+    public fun borrow_share(domain: &RoyaltyDomain, who: &address): &u16 {
+        assert!(
+            vec_map::contains(&domain.royalty_shares_bps, who),
+            err::address_not_attributed()
+        );
+        vec_map::get(&domain.royalty_shares_bps, who)
+    }
+
+    /// Returns a mutable reference to the `Creator` type for the given address
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if the provided address is not an attributed creator
+    fun borrow_share_mut(domain: &mut RoyaltyDomain, who: &address): &mut u16 {
+        assert!(
+            vec_map::contains(&domain.royalty_shares_bps, who),
+            err::address_not_attributed()
+        );
+        vec_map::get_mut(&mut domain.royalty_shares_bps, who)
+    }
+
+    /// Returns whether address is a defined creator
+    public fun contains_share(domain: &RoyaltyDomain, who: &address): bool {
+        vec_map::contains(&domain.royalty_shares_bps, who)
+    }
+
+    /// Returns the list of creators defined on the `CreatorsDomain`
+    public fun borrow_shares(domain: &RoyaltyDomain): &VecMap<address, u16> {
+        &domain.royalty_shares_bps
+    }
+
+    /// Attribute a share of royalties to an address
+    ///
+    /// This must be done by an address which already has an attribution and
+    /// partially gives up a share of their royalties for the benefit of the
+    /// new attribution. Ensures that the total sum of shares remains constant.
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if the transaction sender does not have a large enough royalty
+    /// share to transfer to the new creator or is not attributed in the first
+    /// place.
+    public fun add_share(
+        domain: &mut RoyaltyDomain,
+        who: address,
+        share: u16,
+        ctx: &mut TxContext,
+    ) {
+        // Asserts that sender is a creator
+        let creator = tx_context::sender(ctx);
+        let creator_share = borrow_share_mut(domain, &creator);
+
+        assert!(
+            *creator_share >= share,
+            err::address_does_not_have_enough_shares()
+        );
+
+        *creator_share = *creator_share - share;
+
+        if (*creator_share == 0) {
+            vec_map::remove(&mut domain.royalty_shares_bps, &who);
+        };
+
+        if (contains_share(domain, &who)) {
+            let beneficiary_share = borrow_share_mut(domain, &who);
+            *beneficiary_share = *beneficiary_share + share;
+        } else {
+            vec_map::insert(&mut domain.royalty_shares_bps, who, share);
+        }
+    }
+
+    /// Remove a share attribution from an address
+    ///
+    /// Attributed addresses can only remove their own attributions. Shares of
+    /// the removed attribution are allocated to the provided address which
+    /// must already be attributed. Ensures that the total sum of shares
+    /// remains constant.
+    //
+    // TODO: Create removal methods which split shares evenly and
+    // proportionally.
+    public fun remove_creator_by_transfer(
+        domain: &mut RoyaltyDomain,
+        to: address,
+        ctx: &mut TxContext,
+    ) {
+        // Asserts that sender is a creator
+        let (_, share) = vec_map::remove(
+            &mut domain.royalty_shares_bps,
+            &tx_context::sender(ctx)
+        );
+
+        // Get creator to which shares will be transfered
+        let beneficiary_share = borrow_share_mut(domain, &to);
+        *beneficiary_share = *beneficiary_share + share;
     }
 
     // === Royalties ===
 
-    /// Add a royalty strategy
-    public fun add_royalty_strategy<Strategy: store>(
+    /// Add a generic royalty strategy
+    ///
+    /// Royalty strategies which are not part of the OriginByte standard must
+    /// implement their own calculation methods. Prefer using
+    /// `add_proportional_royalty` and `add_constant_royalty` if only adding
+    /// standard royalty strategies.
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if royalty strategy of the same type was already registered
+    public fun add_royalty_strategy<Strategy: drop + store>(
         domain: &mut RoyaltyDomain,
         strategy: Strategy,
     ) {
@@ -48,14 +241,21 @@ module nft_protocol::royalty {
     }
 
     /// Remove a royalty strategy
-    public fun remove_royalty_strategy<Strategy: store>(
+    ///
+    /// Prefer using `remove_proportional_royalty` and
+    /// `remove_constant_royalty` if only removing standard royalty strategies.
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if strategy was not defined
+    public fun remove_strategy<Strategy: drop + store>(
         domain: &mut RoyaltyDomain,
     ): Strategy {
         bag::remove(&mut domain.strategies, utils::marker<Strategy>())
     }
 
     /// Check whether a royalty strategy is defined
-    public fun contains_royalty_strategy<Strategy: store>(
+    public fun contains_strategy<Strategy: drop + store>(
         domain: &RoyaltyDomain,
     ): bool {
         bag::contains_with_type<Marker<Strategy>, Strategy>(
@@ -64,7 +264,11 @@ module nft_protocol::royalty {
     }
 
     /// Borrow a royalty strategy
-    public fun borrow_royalty_strategy<Strategy: store>(
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if strategy was not defined
+    public fun borrow_strategy<Strategy: drop + store>(
         domain: &RoyaltyDomain,
     ): &Strategy {
         bag::borrow(
@@ -74,9 +278,13 @@ module nft_protocol::royalty {
     }
 
     /// Mutably borrow a royalty strategy
-    public fun borrow_royalty_strategy_mut<Strategy: store>(
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if strategy was not defined
+    public fun borrow_strategy_mut<Strategy: drop + store>(
         domain: &mut RoyaltyDomain,
-    ): &Strategy {
+    ): &mut Strategy {
         bag::borrow_mut(&mut domain.strategies, utils::marker<Strategy>())
     }
 
@@ -85,16 +293,18 @@ module nft_protocol::royalty {
     /// Add proportional royalty policy
     public fun add_proportional_royalty(
         domain: &mut RoyaltyDomain,
-        strategy: BpsRoyaltyStrategy,
+        royalty_fee_bps: u64,
     ) {
+        let strategy = royalty_strategy_bps::new(royalty_fee_bps);
         add_royalty_strategy(domain, strategy);
     }
 
     /// Add constant royalty policy
     public fun add_constant_royalty(
         domain: &mut RoyaltyDomain,
-        strategy: ConstantRoyaltyStrategy,
+        royalty_fee: u64,
     ) {
+        let strategy = royalty_strategy_constant::new(royalty_fee);
         add_royalty_strategy(domain, strategy);
     }
 
@@ -102,14 +312,14 @@ module nft_protocol::royalty {
     public fun remove_proportional_royalty(
         domain: &mut RoyaltyDomain,
     ): BpsRoyaltyStrategy {
-        remove_royalty_strategy<BpsRoyaltyStrategy>(domain)
+        remove_strategy<BpsRoyaltyStrategy>(domain)
     }
 
     /// Remove constant royalty policy
     public fun remove_constant_royalty(
         domain: &mut RoyaltyDomain,
     ): ConstantRoyaltyStrategy {
-        remove_royalty_strategy<ConstantRoyaltyStrategy>(domain)
+        remove_strategy<ConstantRoyaltyStrategy>(domain)
     }
 
     /// Calculate how many tokens are due for the defined proportional royalty
@@ -120,13 +330,7 @@ module nft_protocol::royalty {
         domain: &RoyaltyDomain,
         amount: u64,
     ): u64 {
-        if (!contains_royalty_strategy<BpsRoyaltyStrategy>(domain)) {
-            // TODO: This is dangerous because it can lead to
-            // Silent Failures
-            return 0
-        };
-
-        let strategy = borrow_royalty_strategy<BpsRoyaltyStrategy>(domain);
+        let strategy = borrow_strategy<BpsRoyaltyStrategy>(domain);
         royalty_strategy_bps::calculate(strategy, amount)
     }
 
@@ -137,16 +341,13 @@ module nft_protocol::royalty {
     public fun calculate_constant_royalty(
         domain: &RoyaltyDomain,
     ): u64 {
-        if (!contains_royalty_strategy<ConstantRoyaltyStrategy>(domain)) {
-            return 0
-        };
-
-        let strategy = borrow_royalty_strategy<ConstantRoyaltyStrategy>(domain);
+        let strategy = borrow_strategy<ConstantRoyaltyStrategy>(domain);
         royalty_strategy_constant::calculate(strategy)
     }
 
-    /// === Utils ===
+    // === Utils ===
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     /// Collects an `amount` of tokens from the provided balance into the
@@ -197,23 +398,59 @@ module nft_protocol::royalty {
         collection: &mut Collection<C>,
         ctx: &mut TxContext,
     ) {
-        let creators = *creators::creators_domain(collection);
-
         let domain: &mut RoyaltyDomain =
             collection::borrow_domain_mut(Witness {}, collection);
+
+        let shares = &domain.royalty_shares_bps;
         let aggregate: &mut Balance<FT> = bag::borrow_mut(
             &mut domain.aggregations,
             utils::marker<Balance<FT>>(),
         );
 
-        creators::distribute_balance(
-            &creators,
-            aggregate,
-            ctx,
-        );
+        distribute_balance(shares, aggregate, ctx);
     }
 
-    /// === Interoperability ===
+    /// Distributes the contents of a `Balance<FT>` among the addresses defined
+    /// in `VecMap<address, u16>`
+    ///
+    /// `VecMap<address, u16>` is treated as the basis point share in total
+    /// royalties due to the address.
+    public fun distribute_balance<FT>(
+        shares: &VecMap<address, u16>,
+        aggregate: &mut Balance<FT>,
+        ctx: &mut TxContext,
+    ) {
+        // balance * share_of_royalty_bps / BPS
+        let total = fixed_point32::create_from_rational(
+            balance::value(aggregate),
+            (BPS as u64)
+        );
+
+        let i = 0;
+        while (i < vec_map::size(shares)) {
+            let (who, share) = vec_map::get_entry_by_idx(shares, i);
+
+            // Truncates fractional part of the result thus ensuring that sum
+            // of royalty shares is not greater than total balance.
+            let owed_royalty = fixed_point32::multiply_u64(
+                (*share as u64),
+                total,
+            );
+
+            if (owed_royalty != 0) {
+                let wallet = coin::from_balance(
+                    balance::split(aggregate, owed_royalty),
+                    ctx,
+                );
+
+                transfer::transfer(wallet, *who);
+            };
+
+            i = i + 1;
+        };
+    }
+
+    // === Interoperability ===
 
     /// Get reference to `RoyaltyDomain`
     public fun royalty_domain<C>(
@@ -224,13 +461,13 @@ module nft_protocol::royalty {
 
     /// Get mutable reference to `RoyaltyDomain`
     ///
-    /// Requires that `AttributionDomain` is defined and sender is a creator
+    /// Requires that `CreatorsDomain` is defined and sender is a creator
     public fun royalty_domain_mut<C>(
         collection: &mut Collection<C>,
         ctx: &mut TxContext,
     ): &mut RoyaltyDomain {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         collection::borrow_domain_mut(Witness {}, collection)
@@ -243,5 +480,30 @@ module nft_protocol::royalty {
         domain: RoyaltyDomain,
     ) {
         collection::add_domain(collection, mint_cap, domain);
+    }
+
+    // === Utils ===
+
+    /// Asserts that total shares add up to 10000 basis points or no shares
+    /// exist
+    ///
+    /// ##### Panics
+    ///
+    /// Panics if shares do not add up to 10000 basis points
+    fun assert_total_shares(shares: &VecMap<address, u16>) {
+        let bps_total = 0;
+
+        if (vec_map::is_empty(shares)) {
+            return
+        };
+
+        let i = 0;
+        while (i < vec_map::size(shares)) {
+            let (_, share) = vec_map::get_entry_by_idx(shares, i);
+            bps_total = bps_total + *share;
+            i = i + 1;
+        };
+
+        assert!(bps_total == BPS, err::invalid_total_share_of_royalties());
     }
 }

--- a/sources/standards/royalties/royalty.move
+++ b/sources/standards/royalties/royalty.move
@@ -39,7 +39,7 @@ module nft_protocol::royalty {
     /// ##### Usage
     ///
     /// `RoyaltyDomain` can only calculate royalties owed and distribute them
-    /// to shareholders, but relies on a trusted execution price oracle.
+    /// to shareholders, as a result, it relies on trusted price execution.
     ///
     /// The usage example shows how to derive the owed royalties from the
     /// example sollection, `Suimarines`, which uses `TradePayment` as the
@@ -83,10 +83,10 @@ module nft_protocol::royalty {
         from_shares(vec_map::empty(), ctx)
     }
 
-    /// Creates a `RoyaltyDomain` object with only one creator
+    /// Creates a `RoyaltyDomain` object with only one address attribution
     ///
     /// Only the single address will be able to claim royalties from this
-    /// `RoyaltyDomain` object and modify the `Collection` domains.
+    /// `RoyaltyDomain` object.
     public fun from_address(who: address, ctx: &mut TxContext): RoyaltyDomain {
         let shares = vec_map::empty();
         vec_map::insert(&mut shares, who, BPS);
@@ -94,10 +94,10 @@ module nft_protocol::royalty {
         from_shares(shares, ctx)
     }
 
-    /// Creates a `RoyaltyDomain` with multiple creators
+    /// Creates a `RoyaltyDomain` with multiple attributions
     ///
-    /// Creators will be able to claim royalties and modify `Collection`
-    /// domains.
+    /// Attributed addresses will be able to claim royalties weighted by their
+    /// share in the total royalties.
     ///
     /// ##### Panics
     ///
@@ -163,6 +163,9 @@ module nft_protocol::royalty {
     /// Panics if the transaction sender does not have a large enough royalty
     /// share to transfer to the new creator or is not attributed in the first
     /// place.
+    //
+    // TODO: Add share method for empty RoyaltyDomain controlled by
+    // CreatorsDomain
     public fun add_share(
         domain: &mut RoyaltyDomain,
         who: address,

--- a/sources/standards/royalties/royalty_strategy.move
+++ b/sources/standards/royalties/royalty_strategy.move
@@ -8,6 +8,10 @@ module nft_protocol::royalty_strategy_bps {
         royalty_fee_bps: u64,
     }
 
+    public fun new(royalty_fee_bps: u64): BpsRoyaltyStrategy {
+        BpsRoyaltyStrategy { royalty_fee_bps }
+    }
+
     public fun royalty_fee_bps(domain: &BpsRoyaltyStrategy): u64 {
         domain.royalty_fee_bps
     }
@@ -25,10 +29,6 @@ module nft_protocol::royalty_strategy_bps {
             royalty_rate,
         )
     }
-
-    public fun new(royalty_fee_bps: u64): BpsRoyaltyStrategy {
-        BpsRoyaltyStrategy { royalty_fee_bps }
-    }
 }
 
 module nft_protocol::royalty_strategy_constant {
@@ -37,15 +37,15 @@ module nft_protocol::royalty_strategy_constant {
         royalty_fee: u64,
     }
 
+    public fun new(royalty_fee: u64): ConstantRoyaltyStrategy {
+        ConstantRoyaltyStrategy { royalty_fee}
+    }
+
     public fun royalty_fee(domain: &ConstantRoyaltyStrategy): u64 {
         domain.royalty_fee
     }
 
     public fun calculate(domain: &ConstantRoyaltyStrategy): u64  {
         royalty_fee(domain)
-    }
-
-    public fun new(royalty_fee: u64): ConstantRoyaltyStrategy {
-        ConstantRoyaltyStrategy { royalty_fee}
     }
 }

--- a/sources/standards/tags.move
+++ b/sources/standards/tags.move
@@ -84,6 +84,7 @@ module nft_protocol::tags {
         bag: Bag,
     }
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     public fun empty(ctx: &mut TxContext): TagDomain {
@@ -112,7 +113,7 @@ module nft_protocol::tags {
         let _: T = bag::remove(&mut domain.bag, utils::marker<T>());
     }
 
-    /// ====== Interoperability ===
+    // ====== Interoperability ===
 
     public fun tag_domain<C>(
         nft: &Nft<C>,
@@ -132,7 +133,7 @@ module nft_protocol::tags {
         ctx: &mut TxContext,
     ): &mut TagDomain {
         creators::assert_collection_has_creator(
-            collection, tx_context::sender(ctx)
+            collection, &tx_context::sender(ctx)
         );
 
         collection::borrow_domain_mut(Witness {}, collection)

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -24,6 +24,7 @@ module nft_protocol::bidding {
         transfer_bid_commission,
     };
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     struct Bid<phantom FT> has key {

--- a/sources/trading/ob.move
+++ b/sources/trading/ob.move
@@ -41,6 +41,7 @@ module nft_protocol::ob {
         transfer_bid_commission,
     };
 
+    /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     /// A critbit order book implementation. Contains two ordered trees:

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -228,7 +228,7 @@ module nft_protocol::err {
         return Prefix + 701
     }
 
-    // === AttributionDomain ===
+    // === RoyaltyDomain ===
 
     public fun address_not_attributed(): u64 {
         return Prefix + 800
@@ -240,6 +240,10 @@ module nft_protocol::err {
 
     public fun invalid_total_share_of_royalties(): u64 {
         return Prefix + 802
+    }
+
+    public fun share_attribution_already_exists(): u64 {
+        return Prefix + 803
     }
 
     // === Generic ===

--- a/tests/bidding/safe_to_safe_trade.move
+++ b/tests/bidding/safe_to_safe_trade.move
@@ -19,7 +19,6 @@ module nft_protocol::test_bidding_safe_to_safe_trade {
     use nft_protocol::transfer_allowlist::{Allowlist};
     use nft_protocol::royalties::{Self, TradePayment};
     use nft_protocol::test_utils::{Self as utils};
-    use nft_protocol::royalty_strategy_bps as royalty_bps;
     use nft_protocol::collection::{Self, Collection, MintCap};
 
     use nft_protocol::royalty_strategy_bps::{BpsRoyaltyStrategy};
@@ -129,13 +128,8 @@ module nft_protocol::test_bidding_safe_to_safe_trade {
             mint_cap_id,
         );
 
-        let royalty = royalty::new(ctx(&mut scenario));
-
-        royalty::add_proportional_royalty(
-            &mut royalty,
-            royalty_bps::new(100),
-        );
-
+        let royalty = royalty::from_address(CREATOR, ctx(&mut scenario));
+        royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain<Foo>(
             &mut collection, &mut mint_cap, royalty
         );
@@ -241,7 +235,7 @@ module nft_protocol::test_bidding_safe_to_safe_trade {
         let domain = royalty::royalty_domain(collection);
 
         assert!(
-            royalty::contains_royalty_strategy<BpsRoyaltyStrategy>(domain), 0
+            royalty::contains_strategy<BpsRoyaltyStrategy>(domain), 0
         );
 
         let royalty_owed =

--- a/tests/domains/royalty.move
+++ b/tests/domains/royalty.move
@@ -4,8 +4,6 @@ module nft_protocol::test_royalty {
     use sui::test_scenario::{Self, ctx};
 
     use nft_protocol::royalty::{Self, RoyaltyDomain};
-    use nft_protocol::royalty_strategy_bps as royalty_bps;
-    use nft_protocol::royalty_strategy_constant as royalty_const;
     use nft_protocol::collection::{Self, Collection, MintCap};
     use nft_protocol::test_utils::create_collection_and_allowlist_with_type;
 
@@ -36,18 +34,9 @@ module nft_protocol::test_royalty {
             &scenario, CREATOR, cap_id
         );
 
-        let royalty = royalty::new(ctx(&mut scenario));
-
-        royalty::add_proportional_royalty(
-            &mut royalty,
-            royalty_bps::new(100),
-        );
-
-        royalty::add_constant_royalty(
-            &mut royalty,
-            royalty_const::new(100),
-        );
-
+        let royalty = royalty::from_address(CREATOR, ctx(&mut scenario));
+        royalty::add_proportional_royalty(&mut royalty, 100);
+        royalty::add_constant_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(
             &mut collection, &mut mint_cap, royalty
         );

--- a/tests/mint_and_sell.move
+++ b/tests/mint_and_sell.move
@@ -66,11 +66,8 @@ module nft_protocol::mint_and_sell {
             string::utf8(b"SUIM")
         );
 
-        let royalty = royalty::new(ctx(&mut scenario));
-        royalty::add_proportional_royalty(
-            &mut royalty,
-            nft_protocol::royalty_strategy_bps::new(100),
-        );
+        let royalty = royalty::from_address(CREATOR, ctx(&mut scenario));
+        royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(&mut collection, &mut mint_cap, royalty);
 
         let tags = tags::empty(ctx(&mut scenario));


### PR DESCRIPTION
Refactors RoyaltyDomain and CreatorsDomain to split royalty share and authorization logic.

- Documents both domains in their new form
- Accessibility improvements in creating RoyaltyDomain
- Allow NFTs to be withdrawn from Inventory to an address without going through launchpad