### PR TITLE
Emitting events in orderbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Orderbook event `AskCreatedEvent`/`BidCreatedEvent` are emitted when
+  creating a new position in orderbook.
+- Orderbook event `AskClosedEvent`/`BidClosedEvent` are emitted when
+  closing a position in orderbook.
+- Orderbook event `TradeFilledEvent` is emitted when a trade is filled.
+  That is, either on `create_bid`/`create_ask` when the trade is immediately
+  filled, or on `buy_nft`/`buy_generic_nft`.
+- Royalties event when `TradePayment` is created.
+
+### Fixed
+
+- When creating a bid higher than the lowest ask, the bid is now filled with
+  the lowest ask price.
+  Before, it was filled with the bid price.
+
 ## [0.18.0] - 2023-01-13
 
 ### Changed

--- a/sources/safe/unprotected_safe.move
+++ b/sources/safe/unprotected_safe.move
@@ -31,7 +31,7 @@ module nft_protocol::unprotected_safe {
     use nft_protocol::transfer_allowlist::Allowlist;
     use nft_protocol::utils;
 
-    use sui::event;
+    // use sui::event;
     use sui::object::{Self, ID, UID};
     use sui::transfer::{share_object, transfer};
     use sui::tx_context::{Self, TxContext};
@@ -358,12 +358,12 @@ module nft_protocol::unprotected_safe {
 
         dof::add(&mut safe.id, nft_id, nft);
 
-        event::emit(
-            DepositEvent {
-                safe: object::id(safe),
-                nft: nft_id,
-            }
-        );
+        // event::emit(
+        //     DepositEvent {
+        //         safe: object::id(safe),
+        //         nft: nft_id,
+        //     }
+        // );
     }
 
     fun get_nft_for_transfer_<T>(
@@ -379,12 +379,12 @@ module nft_protocol::unprotected_safe {
     ): T {
         let nft_id = transfer_cap.nft;
 
-        event::emit(
-            TransferEvent {
-                safe: object::id(safe),
-                nft: nft_id,
-            }
-        );
+        // event::emit(
+        //     TransferEvent {
+        //         safe: object::id(safe),
+        //         nft: nft_id,
+        //     }
+        // );
 
         assert_transfer_cap_of_safe(&transfer_cap, safe);
         assert_nft_of_transfer_cap(&nft_id, &transfer_cap);

--- a/sources/safe/unprotected_safe.move
+++ b/sources/safe/unprotected_safe.move
@@ -31,7 +31,7 @@ module nft_protocol::unprotected_safe {
     use nft_protocol::transfer_allowlist::Allowlist;
     use nft_protocol::utils;
 
-    // use sui::event;
+    use sui::event;
     use sui::object::{Self, ID, UID};
     use sui::transfer::{share_object, transfer};
     use sui::tx_context::{Self, TxContext};
@@ -358,12 +358,12 @@ module nft_protocol::unprotected_safe {
 
         dof::add(&mut safe.id, nft_id, nft);
 
-        // event::emit(
-        //     DepositEvent {
-        //         safe: object::id(safe),
-        //         nft: nft_id,
-        //     }
-        // );
+        event::emit(
+            DepositEvent {
+                safe: object::id(safe),
+                nft: nft_id,
+            }
+        );
     }
 
     fun get_nft_for_transfer_<T>(
@@ -379,12 +379,12 @@ module nft_protocol::unprotected_safe {
     ): T {
         let nft_id = transfer_cap.nft;
 
-        // event::emit(
-        //     TransferEvent {
-        //         safe: object::id(safe),
-        //         nft: nft_id,
-        //     }
-        // );
+        event::emit(
+            TransferEvent {
+                safe: object::id(safe),
+                nft: nft_id,
+            }
+        );
 
         assert_transfer_cap_of_safe(&transfer_cap, safe);
         assert_nft_of_transfer_cap(&nft_id, &transfer_cap);

--- a/sources/trading/ob.move
+++ b/sources/trading/ob.move
@@ -42,6 +42,7 @@ module nft_protocol::ob {
     use std::vector;
     use sui::balance::{Self, Balance};
     use sui::coin::{Self, Coin};
+    use sui::event::emit;
     use sui::object::{Self, ID, UID};
     use sui::transfer::{transfer, share_object};
     use sui::tx_context::{Self, TxContext};
@@ -116,8 +117,7 @@ module nft_protocol::ob {
     /// When an ask is matched with a bid, we transfer the ownership of the
     /// [`Ask`] object to the bid owner (buyer).
     /// The buyer can then claim the NFT via [`claim_nft`] endpoint.
-    struct Ask has key, store {
-        id: UID,
+    struct Ask has store {
         /// How many tokens does the seller want for their NFT in exchange.
         price: u64,
         /// Capability to get an NFT from a safe.
@@ -147,40 +147,54 @@ module nft_protocol::ob {
 
     // === Events ===
 
-    struct AskCreated<phantom FT> has copy, drop {
-        id: ID,
+    struct AskCreatedEvent has copy, drop {
         nft: ID,
-        seller: address,
+        orderbook: ID,
         price: u64,
+        seller: address,
     }
 
     /// When de-listed, not when sold!
-    struct AskClosed<phantom FT> has copy, drop {
-        id: ID,
+    struct AskClosedEvent has copy, drop {
         nft: ID,
+        orderbook: ID,
+        price: u64,
         seller: address,
     }
 
-    struct BidCreated<phantom FT> has copy, drop {
-        id: ID,
-        price: u64,
+    struct BidCreatedEvent has copy, drop {
         buyer: address,
+        orderbook: ID,
+        price: u64,
     }
 
     /// When de-listed, not when bought!
-    struct BidClosed<phantom FT> has copy, drop {
-        id: ID,
-        bid: ID,
+    struct BidClosedEvent has copy, drop {
+        buyer: address,
+        orderbook: ID,
+        price: u64,
     }
 
-    struct TradeExecuted<phantom FT> has copy, drop {
-        id: ID,
+    /// Either an ask is created and immediately matched with a bid, or a bid
+    /// is created and immediately matched with an ask.
+    /// In both cases [`TradeFilledEvent`] is emitted.
+    /// In such case, the property `trade_intermediate` is `Some`.
+    ///
+    /// If the NFT was bought directly (`buy_nft` or `buy_generic_nft`), then
+    /// the property `trade_intermediate` is `None`.
+    struct TradeFilledEvent has copy, drop {
+        buyer_safe: ID,
+        buyer: address,
         nft: ID,
         price: u64,
+        seller_safe: ID,
         seller: address,
-        buyer: address,
+        /// Is `None` if the NFT was bought directly (`buy_nft` or
+        /// `buy_generic_nft`.)
+        ///
+        /// Is `Some` if the NFT was bought via `create_bid` or `create_ask`.
+        trade_intermediate: Option<ID>,
     }
-
 
     // === Create bid ===
 
@@ -760,10 +774,6 @@ module nft_protocol::ob {
         let buyer = tx_context::sender(ctx);
         let buyer_safe_id = object::id(buyer_safe);
 
-        // take the amount that the sender wants to create a bid with from their
-        // wallet
-        let bid_offer = balance::split(coin::balance_mut(wallet), price);
-
         let asks = &mut book.asks;
 
         // if map empty, then lowest ask price is 0
@@ -789,27 +799,49 @@ module nft_protocol::ob {
             };
 
             let Ask {
-                id,
                 price: _,
-                owner: _,
+                owner: seller,
                 transfer_cap,
                 commission: ask_commission,
             } = ask;
-            object::delete(id);
+            let nft = safe::transfer_cap_nft(&transfer_cap);
+            let seller_safe = safe::transfer_cap_safe(&transfer_cap);
 
             // see also `finish_trade` entry point
-            share_object(TradeIntermediate<C, FT> {
-                id: object::new(ctx),
-                transfer_cap: option::some(transfer_cap),
-                commission: ask_commission,
-                buyer,
+            let trade_intermediate = TradeIntermediate<C, FT> {
                 buyer_safe: buyer_safe_id,
-                paid: bid_offer,
+                buyer,
+                commission: ask_commission,
+                id: object::new(ctx),
+                paid: balance::split(coin::balance_mut(wallet), lowest_ask_price),
+                transfer_cap: option::some(transfer_cap),
+            };
+            let trade_intermediate_id = object::id(&trade_intermediate);
+            share_object(trade_intermediate);
+
+            emit(TradeFilledEvent {
+                buyer_safe: buyer_safe_id,
+                buyer,
+                nft,
+                price: lowest_ask_price,
+                seller_safe,
+                seller,
+                trade_intermediate: option::some(trade_intermediate_id),
             });
 
             transfer_bid_commission(&mut bid_commission, ctx);
             option::destroy_none(bid_commission);
         } else {
+            emit(BidCreatedEvent {
+                buyer,
+                orderbook: object::id(book),
+                price,
+            });
+
+            // take the amount that the sender wants to create a bid with from their
+            // wallet
+            let bid_offer = balance::split(coin::balance_mut(wallet), price);
+
             let order = Bid {
                 offer: bid_offer,
                 owner: buyer,
@@ -840,6 +872,12 @@ module nft_protocol::ob {
     ) {
         let sender = tx_context::sender(ctx);
 
+        emit(BidClosedEvent {
+            buyer: sender,
+            orderbook: object::id(book),
+            price: bid_price_level,
+        });
+
         let bids = &mut book.bids;
 
         assert!(
@@ -859,8 +897,6 @@ module nft_protocol::ob {
 
             index = index + 1;
         };
-
-
         assert!(index < bids_count, err::order_owner_must_be_sender());
 
         let Bid { offer, owner: _owner, commission, safe: _safe } =
@@ -925,26 +961,46 @@ module nft_protocol::ob {
                 safe: buyer_safe_id,
                 commission: bid_commission,
             } = bid;
+            let paid = balance::value(&bid_offer);
+
+            let nft = safe::transfer_cap_nft(&transfer_cap);
 
             // we cannot transfer the NFT straight away because we don't know
             // the buyers safe at the point of sending the tx
 
             // see also `finish_trade` entry point
-            share_object(TradeIntermediate<C, FT> {
+            let trade_intermediate = TradeIntermediate<C, FT> {
                 id: object::new(ctx),
                 transfer_cap: option::some(transfer_cap),
                 commission: ask_commission,
                 buyer,
                 buyer_safe: buyer_safe_id,
                 paid: bid_offer,
+            };
+            let trade_intermediate_id = object::id(&trade_intermediate);
+            share_object(trade_intermediate);
+
+            emit(TradeFilledEvent {
+                buyer_safe: buyer_safe_id,
+                buyer,
+                nft,
+                price: paid,
+                seller_safe: object::id(seller_safe),
+                seller,
+                trade_intermediate: option::some(trade_intermediate_id),
             });
 
             transfer_bid_commission(&mut bid_commission, ctx);
             option::destroy_none(bid_commission);
         } else {
-            let id = object::new(ctx);
+            emit(AskCreatedEvent {
+                price,
+                orderbook: object::id(book),
+                nft: safe::transfer_cap_nft(&transfer_cap),
+                seller
+            });
+
             let ask = Ask {
-                id,
                 price,
                 owner: seller,
                 transfer_cap,
@@ -962,7 +1018,7 @@ module nft_protocol::ob {
                     price,
                     vector::singleton(ask),
                 );
-            }
+            };
         }
     }
 
@@ -976,7 +1032,6 @@ module nft_protocol::ob {
 
         let Ask {
             owner,
-            id,
             price: _,
             transfer_cap,
             commission: _,
@@ -986,9 +1041,15 @@ module nft_protocol::ob {
             nft_id,
         );
 
+        emit(AskClosedEvent {
+            price: nft_price_level,
+            orderbook: object::id(book),
+            nft: nft_id,
+            seller: sender
+        });
+
         assert!(owner == sender, err::order_owner_must_be_sender());
 
-        object::delete(id);
         transfer(transfer_cap, sender);
     }
 
@@ -1005,7 +1066,6 @@ module nft_protocol::ob {
         let buyer = tx_context::sender(ctx);
 
         let Ask {
-            id,
             transfer_cap,
             owner: _,
             price: _,
@@ -1015,7 +1075,16 @@ module nft_protocol::ob {
             price,
             nft_id,
         );
-        object::delete(id);
+
+        emit(TradeFilledEvent {
+            buyer_safe: object::id(buyer_safe),
+            buyer,
+            nft: nft_id,
+            price,
+            seller_safe: object::id(seller_safe),
+            seller: tx_context::sender(ctx),
+            trade_intermediate: option::none(),
+        });
 
         let bid_offer = balance::split(coin::balance_mut(wallet), price);
 
@@ -1051,7 +1120,6 @@ module nft_protocol::ob {
         let buyer = tx_context::sender(ctx);
 
         let Ask {
-            id,
             transfer_cap,
             owner: _,
             price: _,
@@ -1061,7 +1129,16 @@ module nft_protocol::ob {
             price,
             nft_id,
         );
-        object::delete(id);
+
+        emit(TradeFilledEvent {
+            buyer_safe: object::id(buyer_safe),
+            buyer,
+            nft: nft_id,
+            price,
+            seller_safe: object::id(seller_safe),
+            seller: tx_context::sender(ctx),
+            trade_intermediate: option::none(),
+        });
 
         let bid_offer = balance::split(coin::balance_mut(wallet), price);
 

--- a/sources/trading/ob.move
+++ b/sources/trading/ob.move
@@ -1121,7 +1121,8 @@ module nft_protocol::ob {
 
         let Ask {
             transfer_cap,
-            owner: seller,
+            // owner: seller,
+            owner: _,
             price: _,
             commission: maybe_commission,
         } = remove_ask(
@@ -1130,15 +1131,15 @@ module nft_protocol::ob {
             nft_id,
         );
 
-        event::emit(TradeFilledEvent {
-            buyer_safe: object::id(buyer_safe),
-            buyer,
-            nft: nft_id,
-            price,
-            seller_safe: object::id(seller_safe),
-            seller,
-            trade_intermediate: option::none(),
-        });
+        // event::emit(TradeFilledEvent {
+        //     buyer_safe: object::id(buyer_safe),
+        //     buyer,
+        //     nft: nft_id,
+        //     price,
+        //     seller_safe: object::id(seller_safe),
+        //     seller,
+        //     trade_intermediate: option::none(),
+        // });
 
         let bid_offer = balance::split(coin::balance_mut(wallet), price);
 

--- a/sources/trading/ob.move
+++ b/sources/trading/ob.move
@@ -1087,7 +1087,6 @@ module nft_protocol::ob {
         });
 
         let bid_offer = balance::split(coin::balance_mut(wallet), price);
-
         settle_funds_with_royalties<C, FT>(
             &mut bid_offer,
             buyer,
@@ -1121,8 +1120,7 @@ module nft_protocol::ob {
 
         let Ask {
             transfer_cap,
-            // owner: seller,
-            owner: _,
+            owner: seller,
             price: _,
             commission: maybe_commission,
         } = remove_ask(
@@ -1131,18 +1129,17 @@ module nft_protocol::ob {
             nft_id,
         );
 
-        // event::emit(TradeFilledEvent {
-        //     buyer_safe: object::id(buyer_safe),
-        //     buyer,
-        //     nft: nft_id,
-        //     price,
-        //     seller_safe: object::id(seller_safe),
-        //     seller,
-        //     trade_intermediate: option::none(),
-        // });
+        event::emit(TradeFilledEvent {
+            buyer_safe: object::id(buyer_safe),
+            buyer,
+            nft: nft_id,
+            price,
+            seller_safe: object::id(seller_safe),
+            seller,
+            trade_intermediate: option::none(),
+        });
 
         let bid_offer = balance::split(coin::balance_mut(wallet), price);
-
         settle_funds_no_royalties<C, FT>(
             &mut bid_offer,
             buyer,


### PR DESCRIPTION

### Added

- Orderbook event `AskCreatedEvent`/`BidCreatedEvent` are emitted when
  creating a new position in orderbook.
- Orderbook event `AskClosedEvent`/`BidClosedEvent` are emitted when
  closing a position in orderbook.
- Orderbook event `TradeFilledEvent` is emitted when a trade is filled.
  That is, either on `create_bid`/`create_ask` when the trade is immediately
  filled, or on `buy_nft`/`buy_generic_nft`.
- Royalties event when `TradePayment` is created.

### Fixed

- When creating a bid higher than the lowest ask, the bid is now filled with
  the lowest ask price.
  Before, it was filled with the bid price.