### PR TITLE
Fixed problem with trading in within the same safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2023-01-30
+
+### Fixed
+
+- In orderbook, it was possible to create an ask or a bid which would require
+  that the `finish_trade` function be called with buyer and seller safe as the
+  same object.
+  This is not possible anymore as such tx would result in an error.
+
 ## [0.20.0] - 2023-01-26
 
 ### Added
@@ -32,6 +41,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Royalties event when `TradePayment` is created.
 
 ### Changed
+
 - Updated Sui dep to `0.23.0`
 - Renamed `Inventory` to `Warehouse`
 

--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "NftProtocol"
-version = "0.20.0"
+version = "0.20.1"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
@@ -14,4 +14,4 @@ git = "https://github.com/Origin-Byte/originmate.git"
 rev = "6f599cffa5199edf8dedbdbbe6e4d2a04b576e83"
 
 [addresses]
-nft_protocol = "0x"
+nft_protocol = "0x0"

--- a/Move.toml
+++ b/Move.toml
@@ -14,4 +14,4 @@ git = "https://github.com/Origin-Byte/originmate.git"
 rev = "6f599cffa5199edf8dedbdbbe6e4d2a04b576e83"
 
 [addresses]
-nft_protocol = "0x0"
+nft_protocol = "0x"

--- a/sources/trading/ob.move
+++ b/sources/trading/ob.move
@@ -806,6 +806,10 @@ module nft_protocol::ob {
             } = ask;
             let nft = safe::transfer_cap_nft(&transfer_cap);
             let seller_safe = safe::transfer_cap_safe(&transfer_cap);
+            assert!(
+                seller_safe != buyer_safe_id,
+                err::cannot_trade_with_self(),
+            );
 
             // see also `finish_trade` entry point
             let trade_intermediate = TradeIntermediate<C, FT> {
@@ -961,6 +965,10 @@ module nft_protocol::ob {
                 safe: buyer_safe_id,
                 commission: bid_commission,
             } = bid;
+            assert!(
+                buyer_safe_id != object::id(seller_safe),
+                err::cannot_trade_with_self(),
+            );
             let paid = balance::value(&bid_offer);
 
             let nft = safe::transfer_cap_nft(&transfer_cap);

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -150,6 +150,10 @@ module nft_protocol::err {
         return Prefix + 409
     }
 
+    public fun cannot_trade_with_self(): u64 {
+        return Prefix + 410
+    }
+
     // === Allowlist ===
 
     public fun authority_not_allowlisted(): u64 {

--- a/tests/ob/safe_to_safe_trade.move
+++ b/tests/ob/safe_to_safe_trade.move
@@ -80,4 +80,50 @@ module nft_protocol::test_ob_safe_to_safe_trade {
 
         test_scenario::end(scenario);
     }
+
+    #[test]
+    #[expected_failure(abort_code = 13370410, location = nft_protocol::ob)]
+    fun it_fails_if_buyer_safe_eq_seller_safe() {
+        let scenario = test_scenario::begin(CREATOR);
+
+        test_ob::create_collection_and_allowlist(&mut scenario);
+
+        test_ob::create_ob<test_ob::Foo>(&mut scenario);
+
+        test_ob::create_safe(&mut scenario, SELLER);
+        let nft_id = test_ob::create_and_deposit_nft(
+            &mut scenario,
+            SELLER,
+        );
+        test_ob::create_ask<test_ob::Foo>(
+            &mut scenario,
+            nft_id,
+            OFFER_SUI,
+        );
+        test_ob::create_bid<test_ob::Foo>(&mut scenario, OFFER_SUI);
+
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 13370410, location = nft_protocol::ob)]
+    fun it_fails_if_buyer_safe_eq_seller_safe_with_generic_collection() {
+        let scenario = test_scenario::begin(CREATOR);
+
+        test_ob::create_ob<Box<bool>>(&mut scenario);
+        test_ob::create_safe(&mut scenario, SELLER);
+        let nft_id = test_ob::create_and_deposit_generic_nft(
+            &mut scenario,
+            SELLER,
+        );
+        test_ob::create_ask<Box<bool>>(
+            &mut scenario,
+            nft_id,
+            OFFER_SUI,
+        );
+
+        test_ob::create_bid<Box<bool>>(&mut scenario, OFFER_SUI);
+
+        test_scenario::end(scenario);
+    }
 }


### PR DESCRIPTION

### Fixed

- In orderbook, it was possible to create an ask or a bid which would require
  that the `finish_trade` function be called with buyer and seller safe as the
  same object.
  This is not possible anymore as such tx would result in an error.

---
Closes #227