### PR TITLE
Feature: NFT permissions

### DIFF
--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -32,7 +32,9 @@ module nft_protocol::footbytes {
         collection::add_domain(
             delegated_witness,
             &mut collection,
-            creators::from_address(&witness, tx_context::sender(ctx), ctx),
+            creators::from_address<FOOTBYTES, Witness>(
+                &Witness {}, tx_context::sender(ctx), ctx,
+            ),
         );
 
         // Register custom domains

--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -111,8 +111,7 @@ module nft_protocol::footbytes {
         supply: u64,
         ctx: &mut TxContext,
     ) {
-        let nft =
-            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let nft = nft::from_mint_cap(mint_cap, tx_context::sender(ctx), ctx);
         let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(

--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -27,7 +27,7 @@ module nft_protocol::footbytes {
 
     fun init(witness: FOOTBYTES, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&witness);
+        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
 
         collection::add_domain(
             delegated_witness,
@@ -111,17 +111,14 @@ module nft_protocol::footbytes {
         ctx: &mut TxContext,
     ) {
         let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_display_domain(name, description, ctx),
+        display::add_display_domain(
+            delegated_witness, &mut nft, name, description, ctx,
         );
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_url_domain(url::new_unsafe_from_bytes(url), ctx),
+        display::add_url_domain(
+            delegated_witness, &mut nft, url::new_unsafe_from_bytes(url), ctx,
         );
 
         let template = template::new_regulated(nft, supply, ctx);

--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -110,12 +110,16 @@ module nft_protocol::footbytes {
     ) {
         let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
 
-        display::add_display_domain(
-            &mut nft, name, description, ctx,
+        nft::add_domain_with_mint_cap(
+            mint_cap,
+            &mut nft,
+            display::new_display_domain(name, description, ctx),
         );
 
-        display::add_url_domain(
-            &mut nft, url::new_unsafe_from_bytes(url), ctx,
+        nft::add_domain_with_mint_cap(
+            mint_cap,
+            &mut nft,
+            display::new_url_domain(url::new_unsafe_from_bytes(url), ctx),
         );
 
         let template = template::new_regulated(nft, supply, ctx);

--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -10,6 +10,7 @@ module nft_protocol::footbytes {
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
+    use nft_protocol::witness;
     use nft_protocol::creators;
     use nft_protocol::template;
     use nft_protocol::templates;
@@ -27,7 +28,7 @@ module nft_protocol::footbytes {
 
     fun init(witness: FOOTBYTES, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
+        let delegated_witness = witness::from_witness(&Witness {});
 
         collection::add_domain(
             delegated_witness,
@@ -110,8 +111,9 @@ module nft_protocol::footbytes {
         supply: u64,
         ctx: &mut TxContext,
     ) {
-        let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
+        let nft =
+            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(
             delegated_witness, &mut nft, name, description, ctx,

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -31,7 +31,9 @@ module nft_protocol::suimarines {
         collection::add_domain(
             delegated_witness,
             &mut collection,
-            creators::from_address(&witness, tx_context::sender(ctx), ctx),
+            creators::from_address<SUIMARINES, Witness>(
+                &Witness {}, tx_context::sender(ctx), ctx,
+            ),
         );
 
         // Register custom domains

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -97,24 +97,26 @@ module nft_protocol::suimarines {
     ) {
         let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
 
-        display::add_display_domain(
+        nft::add_domain_with_mint_cap(
+            mint_cap,
             &mut nft,
-            name,
-            description,
-            ctx,
+            display::new_display_domain(name, description, ctx),
         );
 
-        display::add_url_domain(
+        nft::add_domain_with_mint_cap(
+            mint_cap,
             &mut nft,
-            url::new_unsafe_from_bytes(url),
-            ctx,
+            display::new_url_domain(url::new_unsafe_from_bytes(url), ctx),
         );
 
-        display::add_attributes_domain_from_vec(
+        nft::add_domain_with_mint_cap(
+            mint_cap,
             &mut nft,
-            attribute_keys,
-            attribute_values,
-            ctx,
+            display::new_attributes_domain_from_vec(
+                attribute_keys,
+                attribute_values,
+                ctx,
+            ),
         );
 
         warehouse::deposit_nft(warehouse, nft);

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -98,8 +98,7 @@ module nft_protocol::suimarines {
         warehouse: &mut Warehouse<SUIMARINES>,
         ctx: &mut TxContext,
     ) {
-        let nft =
-            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let nft = nft::from_mint_cap(mint_cap, tx_context::sender(ctx), ctx);
         let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -26,7 +26,7 @@ module nft_protocol::suimarines {
 
     fun init(witness: SUIMARINES, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&witness);
+        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
 
         collection::add_domain(
             delegated_witness,
@@ -98,27 +98,18 @@ module nft_protocol::suimarines {
         ctx: &mut TxContext,
     ) {
         let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_display_domain(name, description, ctx),
+        display::add_display_domain(
+            delegated_witness, &mut nft, name, description, ctx,
         );
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_url_domain(url::new_unsafe_from_bytes(url), ctx),
+        display::add_url_domain(
+            delegated_witness, &mut nft, url::new_unsafe_from_bytes(url), ctx,
         );
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_attributes_domain_from_vec(
-                attribute_keys,
-                attribute_values,
-                ctx,
-            ),
+        display::add_attributes_domain_from_vec(
+            delegated_witness, &mut nft, attribute_keys, attribute_values, ctx,
         );
 
         warehouse::deposit_nft(warehouse, nft);

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -10,6 +10,7 @@ module nft_protocol::suimarines {
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
+    use nft_protocol::witness;
     use nft_protocol::creators;
     use nft_protocol::warehouse::{Self, Warehouse};
     use nft_protocol::royalties::{Self, TradePayment};
@@ -26,7 +27,7 @@ module nft_protocol::suimarines {
 
     fun init(witness: SUIMARINES, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
+        let delegated_witness = witness::from_witness(&Witness {});
 
         collection::add_domain(
             delegated_witness,
@@ -97,8 +98,9 @@ module nft_protocol::suimarines {
         warehouse: &mut Warehouse<SUIMARINES>,
         ctx: &mut TxContext,
     ) {
-        let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
+        let nft =
+            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(
             delegated_witness, &mut nft, name, description, ctx,

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -10,6 +10,7 @@ module nft_protocol::suitraders {
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
+    use nft_protocol::witness;
     use nft_protocol::creators;
     use nft_protocol::warehouse::{Self, Warehouse};
     use nft_protocol::royalties::{Self, TradePayment};
@@ -26,7 +27,7 @@ module nft_protocol::suitraders {
 
     fun init(witness: SUITRADERS, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
+        let delegated_witness = witness::from_witness(&Witness {});
 
         collection::add_domain(
             delegated_witness,
@@ -133,8 +134,9 @@ module nft_protocol::suitraders {
         warehouse: &mut Warehouse<SUITRADERS>,
         ctx: &mut TxContext,
     ) {
-        let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
+        let nft =
+            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(
             delegated_witness, &mut nft, name, description, ctx,

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -133,24 +133,26 @@ module nft_protocol::suitraders {
     ) {
         let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
 
-        display::add_display_domain(
+        nft::add_domain_with_mint_cap(
+            mint_cap,
             &mut nft,
-            name,
-            description,
-            ctx,
+            display::new_display_domain(name, description, ctx),
         );
 
-        display::add_url_domain(
+        nft::add_domain_with_mint_cap(
+            mint_cap,
             &mut nft,
-            url::new_unsafe_from_bytes(url),
-            ctx,
+            display::new_url_domain(url::new_unsafe_from_bytes(url), ctx),
         );
 
-        display::add_attributes_domain_from_vec(
+        nft::add_domain_with_mint_cap(
+            mint_cap,
             &mut nft,
-            attribute_keys,
-            attribute_values,
-            ctx,
+            display::new_attributes_domain_from_vec(
+                attribute_keys,
+                attribute_values,
+                ctx,
+            ),
         );
 
         warehouse::deposit_nft(warehouse, nft);

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -11,6 +11,7 @@ module nft_protocol::suitraders {
     use nft_protocol::royalty;
     use nft_protocol::display;
     use nft_protocol::creators;
+    use nft_protocol::witness;
     use nft_protocol::warehouse::{Self, Warehouse};
     use nft_protocol::royalties::{Self, TradePayment};
     use nft_protocol::collection::{Self, Collection};
@@ -31,7 +32,9 @@ module nft_protocol::suitraders {
         collection::add_domain(
             delegated_witness,
             &mut collection,
-            creators::from_address(&witness, tx_context::sender(ctx), ctx),
+            creators::from_address<SUITRADERS, Witness>(
+                &Witness {}, tx_context::sender(ctx), ctx,
+            ),
         );
 
         // Register custom domains
@@ -80,7 +83,7 @@ module nft_protocol::suitraders {
         );
 
         let inventory_id = nft_protocol::listing::create_warehouse<SUITRADERS>(
-            &mut listing, ctx
+            witness::from_witness(&Witness {}), &mut listing, ctx
         );
 
         nft_protocol::fixed_price::init_venue<SUITRADERS, sui::sui::SUI>(

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -134,8 +134,7 @@ module nft_protocol::suitraders {
         warehouse: &mut Warehouse<SUITRADERS>,
         ctx: &mut TxContext,
     ) {
-        let nft =
-            nft::new(&Witness {}, mint_cap, tx_context::sender(ctx), ctx);
+        let nft = nft::from_mint_cap(mint_cap, tx_context::sender(ctx), ctx);
         let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -11,7 +11,6 @@ module nft_protocol::suitraders {
     use nft_protocol::royalty;
     use nft_protocol::display;
     use nft_protocol::creators;
-    use nft_protocol::witness;
     use nft_protocol::warehouse::{Self, Warehouse};
     use nft_protocol::royalties::{Self, TradePayment};
     use nft_protocol::collection::{Self, Collection};
@@ -27,7 +26,7 @@ module nft_protocol::suitraders {
 
     fun init(witness: SUITRADERS, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = nft_protocol::witness::from_witness(&witness);
+        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
 
         collection::add_domain(
             delegated_witness,
@@ -83,7 +82,7 @@ module nft_protocol::suitraders {
         );
 
         let inventory_id = nft_protocol::listing::create_warehouse<SUITRADERS>(
-            witness::from_witness(&Witness {}), &mut listing, ctx
+            delegated_witness, &mut listing, ctx
         );
 
         nft_protocol::fixed_price::init_venue<SUITRADERS, sui::sui::SUI>(
@@ -135,27 +134,18 @@ module nft_protocol::suitraders {
         ctx: &mut TxContext,
     ) {
         let nft = nft::new(mint_cap, tx_context::sender(ctx), ctx);
+        let delegated_witness = nft_protocol::witness::from_witness(&Witness {});
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_display_domain(name, description, ctx),
+        display::add_display_domain(
+            delegated_witness, &mut nft, name, description, ctx,
         );
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_url_domain(url::new_unsafe_from_bytes(url), ctx),
+        display::add_url_domain(
+            delegated_witness, &mut nft, url::new_unsafe_from_bytes(url), ctx,
         );
 
-        nft::add_domain_with_mint_cap(
-            mint_cap,
-            &mut nft,
-            display::new_attributes_domain_from_vec(
-                attribute_keys,
-                attribute_values,
-                ctx,
-            ),
+        display::add_attributes_domain_from_vec(
+            delegated_witness, &mut nft, attribute_keys, attribute_values, ctx,
         );
 
         warehouse::deposit_nft(warehouse, nft);

--- a/examples/whitelisting/free_for_all.move
+++ b/examples/whitelisting/free_for_all.move
@@ -5,6 +5,7 @@
 /// Basically any collection which adds itself to this allowlist is saying:
 /// we're ok with anyone transferring NFTs.
 module nft_protocol::example_free_for_all {
+    use sui::transfer;
     use sui::test_scenario::{Self, ctx};
 
     use nft_protocol::witness;
@@ -30,9 +31,10 @@ module nft_protocol::example_free_for_all {
         );
 
         transfer_allowlist::insert_collection_with_cap(
-            &Witness {}, col_cap, &mut wl,
+            &Witness {}, &col_cap, &mut wl,
         );
 
+        transfer::transfer(col_cap, USER);
         test_scenario::return_shared(wl);
         test_scenario::end(scenario);
     }

--- a/examples/whitelisting/free_for_all.move
+++ b/examples/whitelisting/free_for_all.move
@@ -5,11 +5,10 @@
 /// Basically any collection which adds itself to this allowlist is saying:
 /// we're ok with anyone transferring NFTs.
 module nft_protocol::example_free_for_all {
-    use sui::transfer;
     use sui::test_scenario::{Self, ctx};
 
+    use nft_protocol::witness;
     use nft_protocol::transfer_allowlist::{Self, Allowlist};
-
 
     const USER: address = @0xA1C04;
 
@@ -26,15 +25,14 @@ module nft_protocol::example_free_for_all {
 
         let wl: Allowlist = test_scenario::take_shared(&scenario);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
+        let col_cap = transfer_allowlist::create_collection_cap<Foo>(
+            witness::from_witness(&Witness {}), ctx(&mut scenario),
         );
 
-        transfer_allowlist::insert_collection(
-            &Witness {}, &col_cap, &mut wl,
+        transfer_allowlist::insert_collection_with_cap(
+            &Witness {}, col_cap, &mut wl,
         );
 
-        transfer::transfer(col_cap, USER);
         test_scenario::return_shared(wl);
         test_scenario::end(scenario);
     }

--- a/sources/collection/witness.move
+++ b/sources/collection/witness.move
@@ -1,6 +1,8 @@
 /// Module of the `WitnessGenerator` used for generating authenticating
 /// witnesses on demand.
 module nft_protocol::witness {
+    use nft_protocol::utils;
+
     /// Collection witness generator
     struct WitnessGenerator<phantom C> has store {}
 
@@ -12,8 +14,25 @@ module nft_protocol::witness {
         WitnessGenerator {}
     }
 
+    /// Create a new `WitnessGenerator` from collection witness
+    public fun generator_from_witness<C, W>(
+        _witness: &W,
+    ): WitnessGenerator<C> {
+        utils::assert_same_module_as_witness<C, W>();
+        WitnessGenerator {}
+    }
+
     /// Delegate a witness from collection one time witness
     public fun from_witness<C>(_witness: &C): Witness<C> {
+        Witness {}
+    }
+
+    /// Delegate a witness from collection witness
+    ///
+    /// Useful when you no longer have access to the collection one-time
+    /// witness.
+    public fun from_collection_witness<C, W>(_witness: &W): Witness<C> {
+        utils::assert_same_module_as_witness<C, W>();
         Witness {}
     }
 

--- a/sources/collection/witness.move
+++ b/sources/collection/witness.move
@@ -9,29 +9,14 @@ module nft_protocol::witness {
     /// Collection generic witness type
     struct Witness<phantom C> has copy, drop {}
 
-    /// Create a new `WitnessGenerator` from one-time collection witness
-    public fun generator<C>(_witness: &C): WitnessGenerator<C> {
-        WitnessGenerator {}
-    }
-
     /// Create a new `WitnessGenerator` from collection witness
-    public fun generator_from_witness<C, W>(
-        _witness: &W,
-    ): WitnessGenerator<C> {
+    public fun generator<C, W>(_witness: &W): WitnessGenerator<C> {
         utils::assert_same_module_as_witness<C, W>();
         WitnessGenerator {}
     }
 
-    /// Delegate a witness from collection one time witness
-    public fun from_witness<C>(_witness: &C): Witness<C> {
-        Witness {}
-    }
-
     /// Delegate a witness from collection witness
-    ///
-    /// Useful when you no longer have access to the collection one-time
-    /// witness.
-    public fun from_collection_witness<C, W>(_witness: &W): Witness<C> {
+    public fun from_witness<C, W>(_witness: &W): Witness<C> {
         utils::assert_same_module_as_witness<C, W>();
         Witness {}
     }

--- a/sources/launchpad/factory.move
+++ b/sources/launchpad/factory.move
@@ -7,7 +7,7 @@ module nft_protocol::factory {
 
     use nft_protocol::nft::Nft;
     use nft_protocol::collection::Collection;
-    use nft_protocol::templates as registry;
+    use nft_protocol::templates;
     use nft_protocol::loose_mint_cap::{Self, LooseMintCap};
     use nft_protocol::mint_cap::{RegulatedMintCap, UnregulatedMintCap};
 
@@ -32,13 +32,13 @@ module nft_protocol::factory {
     ///
     /// - Archetype `RegistryDomain` is not registered
     /// - `Archetype` does not exist
-    fun new_regulated<C>(
+    public fun from_regulated<C>(
         mint_cap: RegulatedMintCap<C>,
         collection: &mut Collection<C>,
         template_id: ID,
         ctx: &mut TxContext,
     ): Factory<C> {
-        let mint_cap = registry::delegate(
+        let mint_cap = templates::delegate_regulated(
             mint_cap, collection, template_id, ctx,
         );
 
@@ -55,7 +55,7 @@ module nft_protocol::factory {
         template_id: ID,
         ctx: &mut TxContext,
     ): Factory<C> {
-        let mint_cap = registry::delegate_unregulated(
+        let mint_cap = templates::delegate_unregulated(
             mint_cap, collection, template_id, ctx,
         );
 

--- a/sources/launchpad/factory.move
+++ b/sources/launchpad/factory.move
@@ -84,11 +84,10 @@ module nft_protocol::factory {
     /// Panics if supply was exceeded.
     public fun redeem_nft<C>(
         factory: &mut Factory<C>,
-        owner: address,
         ctx: &mut TxContext,
     ): Nft<C> {
         let mint_cap = borrow_mint_cap_mut(factory);
-        loose_mint_cap::mint_nft(mint_cap, owner, ctx)
+        loose_mint_cap::mint_nft(mint_cap, ctx)
     }
 
     /// Returns the remaining supply available to `Factory`

--- a/sources/launchpad/inventory.move
+++ b/sources/launchpad/inventory.move
@@ -93,21 +93,23 @@ module nft_protocol::inventory {
     /// Endpoint is unprotected and relies on safely obtaining a mutable
     /// reference to `Inventory`.
     ///
+    /// `Inventory` may not change the logical owner of an `Nft` when
+    /// redeeming as this would allow royalties to be trivially bypassed.
+    ///
     /// #### Panics
     ///
     /// Panics if `Warehouse` is empty or if `Factory` has a regulated supply
     /// whose supply was exceeded.
     public fun redeem_nft<C>(
         inventory: &mut Inventory<C>,
-        owner: address,
         ctx: &mut TxContext,
     ): Nft<C> {
         if (is_warehouse(inventory)) {
             let warehouse = borrow_warehouse_mut(inventory);
-            warehouse::redeem_nft(warehouse, owner)
+            warehouse::redeem_nft(warehouse)
         } else {
             let factory = borrow_factory_mut(inventory);
-            factory::redeem_nft(factory, owner, ctx)
+            factory::redeem_nft(factory, tx_context::sender(ctx), ctx)
         }
     }
 
@@ -115,6 +117,9 @@ module nft_protocol::inventory {
     ///
     /// Endpoint is unprotected and relies on safely obtaining a mutable
     /// reference to `Inventory`.
+    ///
+    /// `Inventory` may not change the logical owner of an `Nft` when
+    /// redeeming as this would allow royalties to be trivially bypassed.
     ///
     /// #### Panics
     ///
@@ -125,7 +130,7 @@ module nft_protocol::inventory {
         owner: address,
         ctx: &mut TxContext,
     ) {
-        let nft = redeem_nft(inventory, owner, ctx);
+        let nft = redeem_nft(inventory, ctx);
         transfer::transfer(nft, owner);
     }
 

--- a/sources/launchpad/inventory.move
+++ b/sources/launchpad/inventory.move
@@ -109,8 +109,10 @@ module nft_protocol::inventory {
             warehouse::redeem_nft(warehouse)
         } else {
             let factory = borrow_factory_mut(inventory);
-            factory::redeem_nft(factory, tx_context::sender(ctx), ctx)
+            factory::redeem_nft(factory, ctx)
         }
+
+        // TODO: Change owner?
     }
 
     /// Redeems NFT from `Inventory`

--- a/sources/launchpad/inventory.move
+++ b/sources/launchpad/inventory.move
@@ -1,18 +1,22 @@
 /// Module of `Inventory` type, a type-erased wrapper around `Warehouse` and
-/// `Factory`
+/// `Factory`.
+///
+/// Additionally, `Inventory` is responsible for providing a safe interface to
+/// change the logical owner of NFTs redeemed from it.
 module nft_protocol::inventory {
     use std::option::{Self, Option};
 
     use sui::transfer;
-    use sui::tx_context;
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
     use sui::dynamic_field as df;
 
-    use nft_protocol::nft::Nft;
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::utils::{Self, Marker};
     use nft_protocol::factory::{Self, Factory};
     use nft_protocol::warehouse::{Self, Warehouse};
+    use nft_protocol::transfer_allowlist::{Self, Allowlist};
+    use nft_protocol::witness::Witness as DelegatedWitness;
 
     /// `Inventory` is not a `Warehouse`
     ///
@@ -24,52 +28,48 @@ module nft_protocol::inventory {
     /// Call `from_factory` to create an `Inventory` from `Factory`
     const ENOT_FACTORY: u64 = 2;
 
+    struct Witness has drop {}
+
     /// A type-erased wrapper around `Warehouse` and `Factory`
     struct Inventory<phantom C> has key, store {
         /// `Inventory` ID
         id: UID,
+        /// Internal `Inventory` `Allowlist` for changing `Nft` owners
+        allowlist: Allowlist,
     }
 
     /// Create a new `Inventory` from a `Warehouse`
     public fun from_warehouse<C>(
+        witness: DelegatedWitness<C>,
         warehouse: Warehouse<C>,
         ctx: &mut TxContext,
     ): Inventory<C> {
         let inventory_id = object::new(ctx);
         df::add(&mut inventory_id, utils::marker<Warehouse<C>>(), warehouse);
 
-        Inventory { id: inventory_id }
-    }
+        let allowlist = transfer_allowlist::create(&Witness {}, ctx);
+        transfer_allowlist::insert_collection(
+            &Witness {}, witness, &mut allowlist,
+        );
 
-    /// Create a new `Inventory` from a `Warehouse` and transfer to transaction
-    /// sender
-    public entry fun init_from_warehouse<C>(
-        warehouse: Warehouse<C>,
-        ctx: &mut TxContext,
-    ) {
-        let inventory = from_warehouse(warehouse, ctx);
-        transfer::transfer(inventory, tx_context::sender(ctx));
+        Inventory { id: inventory_id, allowlist }
     }
 
     /// Create a new `Inventory` from a `Factory`
     public fun from_factory<C>(
+        witness: DelegatedWitness<C>,
         factory: Factory<C>,
         ctx: &mut TxContext,
     ): Inventory<C> {
         let inventory_id = object::new(ctx);
         df::add(&mut inventory_id, utils::marker<Factory<C>>(), factory);
 
-        Inventory { id: inventory_id }
-    }
+        let allowlist = transfer_allowlist::create(&Witness {}, ctx);
+        transfer_allowlist::insert_collection(
+            &Witness {}, witness, &mut allowlist,
+        );
 
-    /// Create a new `Inventory` from a `Factory` and transfer to transaction
-    /// sender
-    public entry fun init_from_factory<C>(
-        factory: Factory<C>,
-        ctx: &mut TxContext,
-    ) {
-        let inventory = from_factory(factory, ctx);
-        transfer::transfer(inventory, tx_context::sender(ctx));
+         Inventory { id: inventory_id, allowlist }
     }
 
     /// Deposits NFT to `Inventory`
@@ -93,26 +93,33 @@ module nft_protocol::inventory {
     /// Endpoint is unprotected and relies on safely obtaining a mutable
     /// reference to `Inventory`.
     ///
-    /// `Inventory` may not change the logical owner of an `Nft` when
-    /// redeeming as this would allow royalties to be trivially bypassed.
+    /// Requires `Allowlist` authority token. See
+    /// [transfer](nft.html#transfer).
     ///
     /// #### Panics
     ///
-    /// Panics if `Warehouse` is empty or if `Factory` has a regulated supply
-    /// whose supply was exceeded.
+    /// Panics if no supply is available or authority token was invalid.
     public fun redeem_nft<C>(
         inventory: &mut Inventory<C>,
+        owner: address,
         ctx: &mut TxContext,
     ): Nft<C> {
-        if (is_warehouse(inventory)) {
+        let nft = if (is_warehouse(inventory)) {
             let warehouse = borrow_warehouse_mut(inventory);
             warehouse::redeem_nft(warehouse)
         } else {
             let factory = borrow_factory_mut(inventory);
             factory::redeem_nft(factory, ctx)
-        }
+        };
 
-        // TODO: Change owner?
+        nft::change_logical_owner(
+            &mut nft,
+            owner,
+            Witness {}, // Any Auth will work
+            &inventory.allowlist
+        );
+
+        nft
     }
 
     /// Redeems NFT from `Inventory`
@@ -120,19 +127,18 @@ module nft_protocol::inventory {
     /// Endpoint is unprotected and relies on safely obtaining a mutable
     /// reference to `Inventory`.
     ///
-    /// `Inventory` may not change the logical owner of an `Nft` when
-    /// redeeming as this would allow royalties to be trivially bypassed.
+    /// Requires `Allowlist` authority token. See
+    /// [transfer_with_auth](nft.html#transfer_with_auth).
     ///
     /// #### Panics
     ///
-    /// Panics if `Warehouse` is empty or if `Factory` has a regulated supply
-    /// whose supply was exceeded.
-    public entry fun redeem_nft_and_transfer<C>(
+    /// Panics if no supply is available or authority token was invalid.
+    public entry fun transfer<C>(
         inventory: &mut Inventory<C>,
         owner: address,
         ctx: &mut TxContext,
     ) {
-        let nft = redeem_nft(inventory, ctx);
+        let nft = redeem_nft(inventory, owner, ctx);
         transfer::transfer(nft, owner);
     }
 

--- a/sources/launchpad/listing.move
+++ b/sources/launchpad/listing.move
@@ -294,12 +294,6 @@ module nft_protocol::listing {
         // If there the listing is not attached to a marketplace
         // then if does not make sense to pay fees.
         mkt::assert_marketplace_admin(marketplace, ctx);
-
-        assert!(
-            obox::is_empty(&listing.custom_fee),
-            err::generic_box_full(),
-        );
-
         obox::add<FeeType>(&mut listing.custom_fee, fee);
     }
 

--- a/sources/launchpad/market/dutch_auction.move
+++ b/sources/launchpad/market/dutch_auction.move
@@ -273,7 +273,7 @@ module nft_protocol::dutch_auction {
 
             balance::join<FT>(&mut total_funds, filled_funds);
 
-            inventory::redeem_nft_and_transfer(inventory, owner, ctx);
+            inventory::transfer(inventory, owner, ctx);
 
             if (balance::value(&amount) == 0) {
                 balance::destroy_zero(amount);

--- a/sources/launchpad/market/dutch_auction.move
+++ b/sources/launchpad/market/dutch_auction.move
@@ -267,7 +267,7 @@ module nft_protocol::dutch_auction {
 
         let total_funds = balance::zero<FT>();
         while (!vector::is_empty(&bids_to_fill)) {
-            let Bid {amount, owner} = vector::pop_back(&mut bids_to_fill);
+            let Bid { amount, owner } = vector::pop_back(&mut bids_to_fill);
 
             let filled_funds = balance::split(&mut amount, fill_price);
 
@@ -321,7 +321,7 @@ module nft_protocol::dutch_auction {
         wallet: &mut Coin<FT>,
         price: u64,
         quantity: u64,
-        bidder: address,
+        owner: address,
     ) {
         assert!(
             price >= auction.reserve_price,
@@ -344,7 +344,7 @@ module nft_protocol::dutch_auction {
         let index = 0;
         while (quantity > index) {
             let amount = balance::split(coin::balance_mut(wallet), price);
-            vector::push_back(price_level, Bid { amount, owner: bidder });
+            vector::push_back(price_level, Bid { amount, owner });
             index = index + 1;
         }
     }

--- a/sources/launchpad/market/fixed_price.move
+++ b/sources/launchpad/market/fixed_price.move
@@ -145,7 +145,7 @@ module nft_protocol::fixed_price {
             );
 
         let owner = tx_context::sender(ctx);
-        inventory::redeem_nft_and_transfer(inventory, owner, ctx);
+        inventory::transfer(inventory, owner, ctx);
 
         listing::pay(listing, funds, 1);
     }

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -89,21 +89,30 @@ module nft_protocol::nft {
 
     /// Create a new `Nft`
     ///
+    /// This operation is authorized using a `MintCap` but also requires that
+    /// it is called inside the original contract.
+    /// This restriction is imposed in order to allow `MintCap` to be shared
+    /// and provide a protected API for minting NFTs.
+    /// If you want to delegate minting of NFTs outside of the defining
+    /// contract, see [new_regulated](#new_regulated) or
+    /// [new_unregulated](#new_unregulated).
+    ///
     /// #### Usage
     ///
     /// ```
     /// struct SUIMARINES has drop {}
     ///
     /// fun init(witness: SUIMARINES, ctx: &mut TxContext) {
-    ///
     ///     let nft = nft::new(&witness, tx_context::sender(ctx), ctx);
     /// }
     /// ```
-    public fun new<C>(
+    public fun new<C, W>(
+        _witness: &W,
         _mint_cap: &MintCap<C>,
         owner: address,
         ctx: &mut TxContext,
     ): Nft<C> {
+        utils::assert_same_module_as_witness<C, W>();
         new_(owner, ctx)
     }
 

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -281,11 +281,13 @@ module nft_protocol::nft {
     /// #### Panics
     ///
     /// Panics if domain `D` already exists.
-    public fun add_domain_with_mint_cap<C, D: key + store>(
+    public fun add_domain_with_mint_cap<C, D: key + store, W>(
+        _witness: &W,
         _mint_cap: &MintCap<C>,
         nft: &mut Nft<C>,
         domain: D,
     ) {
+        utils::assert_same_module_as_witness<W, C>();
         add_domain_(nft, domain)
     }
 

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -23,8 +23,6 @@ module nft_protocol::nft {
         Self, MintCap, RegulatedMintCap, UnregulatedMintCap,
     };
 
-    friend nft_protocol::inventory;
-
     /// Domain not defined
     ///
     /// Call `collection::add_domain` to add domains

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -87,32 +87,33 @@ module nft_protocol::nft {
         }
     }
 
-    /// Create a new `Nft`
-    ///
-    /// This operation is authorized using a `MintCap` but also requires that
-    /// it is called inside the original contract.
-    /// This restriction is imposed in order to allow `MintCap` to be shared
-    /// and provide a protected API for minting NFTs.
-    /// If you want to delegate minting of NFTs outside of the defining
-    /// contract, see [new_regulated](#new_regulated) or
-    /// [new_unregulated](#new_unregulated).
+    /// Create a new `Nft` using `MintCap`
     ///
     /// #### Usage
     ///
     /// ```
+    /// struct Witness has drop {}
     /// struct SUIMARINES has drop {}
     ///
     /// fun init(witness: SUIMARINES, ctx: &mut TxContext) {
-    ///     let nft = nft::new(&witness, tx_context::sender(ctx), ctx);
+    ///     let nft = nft::new(&Witness {}, tx_context::sender(ctx), ctx);
     /// }
     /// ```
     public fun new<C, W>(
         _witness: &W,
-        _mint_cap: &MintCap<C>,
         owner: address,
         ctx: &mut TxContext,
     ): Nft<C> {
         utils::assert_same_module_as_witness<C, W>();
+        new_(owner, ctx)
+    }
+
+    /// Create a new `Nft` using `MintCap`
+    public fun from_mint_cap<C>(
+        _mint_cap: &MintCap<C>,
+        owner: address,
+        ctx: &mut TxContext,
+    ): Nft<C> {
         new_(owner, ctx)
     }
 
@@ -130,7 +131,7 @@ module nft_protocol::nft {
     /// #### Panics
     ///
     /// Panics if supply is exceeded.
-    public fun new_regulated<C>(
+    public fun from_regulated<C>(
         mint_cap: &mut RegulatedMintCap<C>,
         ctx: &mut TxContext,
     ): Nft<C> {
@@ -149,7 +150,7 @@ module nft_protocol::nft {
     /// to add domains to NFTs not belonging to the transaction sender.
     ///
     /// See [new](#new) for usage information.
-    public fun new_unregulated<C>(
+    public fun from_unregulated<C>(
         _mint_cap: &UnregulatedMintCap<C>,
         ctx: &mut TxContext,
     ): Nft<C> {
@@ -282,7 +283,6 @@ module nft_protocol::nft {
     ///
     /// Panics if domain `D` already exists.
     public fun add_domain_with_mint_cap<C, D: key + store, W>(
-        _witness: &W,
         _mint_cap: &MintCap<C>,
         nft: &mut Nft<C>,
         domain: D,

--- a/sources/safe/transfer_allowlist.move
+++ b/sources/safe/transfer_allowlist.move
@@ -21,9 +21,6 @@
 ///     version of their witness type. The OB then uses this witness type
 ///     to authorize transfers.
 module nft_protocol::transfer_allowlist {
-    use nft_protocol::utils;
-    use nft_protocol::err;
-
     use std::option::{Self, Option};
     use std::type_name::{Self, TypeName};
 
@@ -31,6 +28,26 @@ module nft_protocol::transfer_allowlist {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
     use sui::vec_set::{Self, VecSet};
+
+    use nft_protocol::witness::Witness as DelegatedWitness;
+
+    /// Invalid admin
+    ///
+    /// Create new `Allowlist` using `create` with desired admin.
+    const EINVALID_ADMIN: u64 = 1;
+
+    /// Invalid collection
+    ///
+    /// Call `insert_collection` to insert a collection.
+    const EINVALID_COLLECTION: u64 = 2;
+
+    /// Invalid transfer authority
+    ///
+    /// Call `insert_authority` to insert an authority.
+    const EINVALID_AUTHORITY: u64 = 3;
+
+    /// `Allowlist` requires an authority to be provided
+    const EREQUIRES_AUTHORITTY: u64 = 4;
 
     struct Allowlist has key, store {
         id: UID,
@@ -82,14 +99,22 @@ module nft_protocol::transfer_allowlist {
     }
 
     /// See the docs for struct `CollectionControlCap`.
-    public fun create_collection_cap<C, W>(
-        _witness: &W,
+    public fun create_collection_cap<C>(
+        _witness: DelegatedWitness<C>,
         ctx: &mut TxContext,
     ): CollectionControlCap<C> {
-        utils::assert_same_module_as_witness<C, W>();
         CollectionControlCap {
             id: object::new(ctx),
         }
+    }
+
+    public fun insert_collection<Admin, C>(
+        _allowlist_witness: &Admin,
+        _collection_witness: DelegatedWitness<C>,
+        list: &mut Allowlist,
+    ) {
+        assert_admin_witness<Admin>(list);
+        vec_set::insert(&mut list.collections, type_name::get<C>());
     }
 
     /// To add a collection to the list, we need a confirmation by both the
@@ -99,9 +124,9 @@ module nft_protocol::transfer_allowlist {
     /// collection to the allowlist, they can reexport this function in their
     /// module without the witness protection. However, we opt for witness
     /// collection to give the allowlist owner a way to combat spam.
-    public fun insert_collection<Admin, C>(
+    public fun insert_collection_with_cap<Admin, C>(
         _allowlist_witness: &Admin,
-        _authority: &CollectionControlCap<C>,
+        _authority: CollectionControlCap<C>,
         list: &mut Allowlist,
     ) {
         assert_admin_witness<Admin>(list);
@@ -173,30 +198,70 @@ module nft_protocol::transfer_allowlist {
         );
     }
 
-    /// Checks whether given authority witness is in the allowlist, and also
-    /// whether given collection witness (C) is in the allowlist.
-    public fun can_be_transferred<C, Auth: drop>(
-        _authority_witness: Auth,
-        allowlist: &Allowlist,
-    ): bool {
-        let applies_to_collection =
-            vec_set::contains(&allowlist.collections, &type_name::get<C>());
-
-        if (option::is_none(&allowlist.authorities)) {
-            return applies_to_collection
-        };
-
-        let e = option::borrow(&allowlist.authorities);
-
-        applies_to_collection && vec_set::contains(e, &type_name::get<Auth>())
+    /// Returns whether `Allowlist` contains collection `C`
+    public fun contains_collection<C>(allowlist: &Allowlist): bool {
+        vec_set::contains(&allowlist.collections, &type_name::get<C>())
     }
 
-    fun assert_admin_witness<Admin>(
-        list: &Allowlist,
-    ) {
+    /// Returns whether `Allowlist` contains authority `Auth`
+    public fun contains_authority<Auth>(allowlist: &Allowlist): bool {
+        if (option::is_none(&allowlist.authorities)) {
+            // If no authorities are defined this effectively means that all
+            // authorities are registered.
+            true
+        } else {
+            let e = option::borrow(&allowlist.authorities);
+            vec_set::contains(e, &type_name::get<Auth>())
+        }
+    }
+
+    /// Returns whether `Allowlist` requires an authority to transfer
+    public fun requires_authority(allowlist: &Allowlist): bool {
+        option::is_some(&allowlist.authorities)
+    }
+
+    // === Assertions ===
+
+    /// Asserts that witness is admin of `Allowlist`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if admin is mismatched
+    fun assert_admin_witness<Admin>(list: &Allowlist) {
         assert!(
             type_name::get<Admin>() == list.admin_witness,
-            err::sender_not_allowlist_admin(),
+            EINVALID_ADMIN,
         );
+    }
+
+    /// Assert that `Nft<C>` may be transferred using this `Allowlist`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Nft<C>` may not be transferred.
+    public fun assert_collection<C>(allowlist: &Allowlist) {
+        assert!(
+            contains_collection<C>(allowlist), EINVALID_COLLECTION,
+        );
+    }
+
+    /// Assert that `Nft<C>` may be transferred using this `Allowlist`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Nft<C>` may not be transferred.
+    public fun assert_authority<Auth: drop>(allowlist: &Allowlist) {
+        assert!(
+            contains_authority<Auth>(allowlist), EINVALID_AUTHORITY,
+        );
+    }
+
+    /// Assert that `Allowlist` does not require using an authority
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Allowlist` requires an authority
+    public fun assert_no_authority(allowlist: &Allowlist) {
+        assert!(requires_authority(allowlist), EREQUIRES_AUTHORITTY)
     }
 }

--- a/sources/safe/unprotected_safe.move
+++ b/sources/safe/unprotected_safe.move
@@ -233,7 +233,6 @@ module nft_protocol::unprotected_safe {
         safe: &mut UnprotectedSafe,
     ) {
         let nft = get_nft_for_transfer_<T>(transfer_cap, safe);
-
         nft::transfer(nft, recipient, authority, allowlist);
     }
 
@@ -266,7 +265,6 @@ module nft_protocol::unprotected_safe {
         ctx: &mut TxContext,
     ) {
         let nft = get_nft_for_transfer_<T>(transfer_cap, source);
-
         nft::change_logical_owner(&mut nft, recipient, authority, allowlist);
         deposit_nft(nft, target, ctx);
     }

--- a/sources/safe/unprotected_safe.move
+++ b/sources/safe/unprotected_safe.move
@@ -233,6 +233,7 @@ module nft_protocol::unprotected_safe {
         safe: &mut UnprotectedSafe,
     ) {
         let nft = get_nft_for_transfer_<T>(transfer_cap, safe);
+
         nft::transfer(nft, recipient, authority, allowlist);
     }
 
@@ -265,6 +266,7 @@ module nft_protocol::unprotected_safe {
         ctx: &mut TxContext,
     ) {
         let nft = get_nft_for_transfer_<T>(transfer_cap, source);
+
         nft::change_logical_owner(&mut nft, recipient, authority, allowlist);
         deposit_nft(nft, target, ctx);
     }

--- a/sources/standards/creators.move
+++ b/sources/standards/creators.move
@@ -81,8 +81,8 @@ module nft_protocol::creators {
     ///
     /// Only the single `Creator` will ever be able to modify `Collection`
     /// domains.
-    public fun from_address<C>(
-        witness: &C,
+    public fun from_address<C, W>(
+        witness: &W,
         who: address,
         ctx: &mut TxContext,
     ): CreatorsDomain<C> {
@@ -95,14 +95,14 @@ module nft_protocol::creators {
     /// Creates a `CreatorsDomain` with multiple creators
     ///
     /// Each attributed creator will be able to modify `Collection` domains.
-    public fun from_creators<C>(
-        witness: &C,
+    public fun from_creators<C, W>(
+        witness: &W,
         creators: VecSet<address>,
         ctx: &mut TxContext,
     ): CreatorsDomain<C> {
         CreatorsDomain {
             id: object::new(ctx),
-            generator: witness::generator(witness),
+            generator: witness::generator<C, W>(witness),
             creators,
         }
     }

--- a/sources/standards/creators.move
+++ b/sources/standards/creators.move
@@ -148,7 +148,7 @@ module nft_protocol::creators {
     /// Panics if transaction sender was not a creator or `CreatorsDomain` was
     /// not registered on the `Collection`.
     public fun delegate<C>(
-        collection: &mut Collection<C>,
+        collection: &Collection<C>,
         ctx: &mut TxContext,
     ): DelegatedWitness<C> {
         let domain = creators_domain(collection);

--- a/sources/standards/display.move
+++ b/sources/standards/display.move
@@ -90,12 +90,15 @@ module nft_protocol::display {
     }
 
     public fun add_display_domain<C>(
+        witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
         name: String,
         description: String,
         ctx: &mut TxContext,
     ) {
-        nft::add_domain(nft, new_display_domain(name, description, ctx), ctx);
+        nft::add_domain(
+            witness, nft, new_display_domain(name, description, ctx),
+        );
     }
 
     public fun add_collection_display_domain<C>(
@@ -160,11 +163,14 @@ module nft_protocol::display {
     }
 
     public fun add_url_domain<C>(
+        witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
         url: Url,
         ctx: &mut TxContext,
     ) {
-        nft::add_domain(nft, new_url_domain(url, ctx), ctx);
+        nft::add_domain(
+            witness, nft, new_url_domain(url, ctx),
+        );
     }
 
     public fun add_collection_url_domain<C>(
@@ -231,11 +237,14 @@ module nft_protocol::display {
     }
 
     public fun add_symbol_domain<C>(
+        witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
         symbol: String,
         ctx: &mut TxContext,
     ) {
-        nft::add_domain(nft, new_symbol_domain(symbol, ctx), ctx);
+        nft::add_domain(
+            witness, nft, new_symbol_domain(symbol, ctx),
+        );
     }
 
     public fun add_collection_symbol_domain<C>(
@@ -279,6 +288,15 @@ module nft_protocol::display {
         AttributesDomain { id: object::new(ctx), map }
     }
 
+    public fun new_attributes_domain_from_vec(
+        keys: vector<String>,
+        values: vector<String>,
+        ctx: &mut TxContext,
+    ): AttributesDomain {
+        let map = utils::from_vec_to_map<String, String>(keys, values);
+        new_attributes_domain(map, ctx)
+    }
+
     // ====== Interoperability ===
 
     public fun display_attribute<C>(nft: &Nft<C>): &AttributesDomain {
@@ -293,21 +311,27 @@ module nft_protocol::display {
     }
 
     public fun add_attributes_domain<C>(
+        witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
         map: VecMap<String, String>,
         ctx: &mut TxContext,
     ) {
-        nft::add_domain(nft, new_attributes_domain(map, ctx), ctx);
+        nft::add_domain(
+            witness, nft, new_attributes_domain(map, ctx),
+        );
     }
 
     public fun add_attributes_domain_from_vec<C>(
+        witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
         keys: vector<String>,
         values: vector<String>,
         ctx: &mut TxContext,
     ) {
-        let map =  utils::from_vec_to_map<String, String>(keys, values);
-
-        nft::add_domain(nft, new_attributes_domain(map, ctx), ctx);
+        nft::add_domain(
+            witness,
+            nft,
+            new_attributes_domain_from_vec(keys, values, ctx),
+        );
     }
 }

--- a/sources/standards/loose/mint_cap.move
+++ b/sources/standards/loose/mint_cap.move
@@ -176,23 +176,22 @@ module nft_protocol::loose_mint_cap {
     /// Panics if supply was exceeded.
     public fun mint_nft<C>(
         mint_cap: &mut LooseMintCap<C>,
-        owner: address,
         ctx: &mut TxContext,
     ): Nft<C> {
-        let pointer = pointer(mint_cap.archetype_id, ctx);
+        let pointer = pointer(mint_cap.template_id, ctx);
 
         if (is_regulated(mint_cap)) {
             let mint_cap = borrow_regulated_mut(mint_cap);
-            let nft = nft::new_regulated(mint_cap, owner, ctx);
+            let nft = nft::new_regulated(mint_cap, ctx);
 
-            nft::add_domain_with_regulated(mint_cap, &mut nft, pointer);
+            nft::add_domain_with_regulated(mint_cap, &mut nft, pointer, ctx);
 
             nft
         } else {
             let mint_cap = borrow_unregulated(mint_cap);
-            let nft = nft::new_unregulated(mint_cap, owner, ctx);
+            let nft = nft::new_unregulated(mint_cap, ctx);
 
-            nft::add_domain_with_unregulated(mint_cap, &mut nft, pointer);
+            nft::add_domain_with_unregulated(mint_cap, &mut nft, pointer, ctx);
 
             nft
         }
@@ -207,8 +206,7 @@ module nft_protocol::loose_mint_cap {
         mint_cap: &mut LooseMintCap<C>,
         ctx: &mut TxContext,
     ) {
-        let sender = tx_context::sender(ctx);
-        let nft = mint_nft(mint_cap, sender, ctx);
-        transfer::transfer(nft, sender);
+        let nft = mint_nft(mint_cap, ctx);
+        transfer::transfer(nft, tx_context::sender(ctx));
     }
 }

--- a/sources/standards/loose/mint_cap.move
+++ b/sources/standards/loose/mint_cap.move
@@ -182,14 +182,14 @@ module nft_protocol::loose_mint_cap {
 
         if (is_regulated(mint_cap)) {
             let mint_cap = borrow_regulated_mut(mint_cap);
-            let nft = nft::new_regulated(mint_cap, ctx);
+            let nft = nft::from_regulated(mint_cap, ctx);
 
             nft::add_domain_with_regulated(mint_cap, &mut nft, pointer, ctx);
 
             nft
         } else {
             let mint_cap = borrow_unregulated(mint_cap);
-            let nft = nft::new_unregulated(mint_cap, ctx);
+            let nft = nft::from_unregulated(mint_cap, ctx);
 
             nft::add_domain_with_unregulated(mint_cap, &mut nft, pointer, ctx);
 

--- a/sources/standards/loose/templates.move
+++ b/sources/standards/loose/templates.move
@@ -170,7 +170,7 @@ module nft_protocol::templates {
     ///
     /// Panics if template `TemplatesDomain` is not registered on `Collection`
     /// or `Template` does not exist.
-    public fun delegate<C>(
+    public fun delegate_regulated<C>(
         mint_cap: RegulatedMintCap<C>,
         collection: &mut Collection<C>,
         template_id: ID,

--- a/sources/standards/modify.move
+++ b/sources/standards/modify.move
@@ -12,7 +12,9 @@ module nft_protocol::modify {
 
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::collection::{Self, Collection};
-    use nft_protocol::witness::{Self, WitnessGenerator};
+    use nft_protocol::witness::{
+        Self, WitnessGenerator,
+    };
 
     /// `ModifyDomain` was not defined on `Collection`
     ///
@@ -77,7 +79,7 @@ module nft_protocol::modify {
     ) {
         let domain = new(witness, ctx);
         collection::add_domain(
-            witness::from_witness(witness),
+            witness::from_collection_witness(witness),
             collection,
             domain,
         );

--- a/sources/standards/modify.move
+++ b/sources/standards/modify.move
@@ -1,0 +1,121 @@
+/// Module of NFT `ModifyDomain`
+///
+/// `ModifyDomain` allows collection creators to delegate users
+/// the right to independently register new domains on their NFTs without
+/// delegating the right to mint or modify the collection.
+///
+/// An alternative is delegating a `RegulatedMintCap` with zero supply
+/// which will allow users or contracts to register domains on
+module nft_protocol::modify {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+
+    use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::collection::{Self, Collection};
+    use nft_protocol::witness::{Self, WitnessGenerator};
+
+    /// `ModifyDomain` was not defined on `Collection`
+    ///
+    /// Call `modify::add_modify_domain` to add `ModifyDomain`.
+    const EUNDEFINED_MODIFY_DOMAIN: u64 = 1;
+
+    /// Transaction sender was not the logical owner of the NFT
+    const EINVALID_LOGICAL_OWNER: u64 = 2;
+
+    /// `ModifyDomain` object
+    struct ModifyDomain<phantom C> has key, store {
+        /// `ModifyDomain` ID
+        id: UID,
+        /// Generator responsible for issuing delegated witnesses
+        generator: WitnessGenerator<C>,
+    }
+
+    /// Creates a new `ModifyDomain`
+    fun new<C>(witness: &C, ctx: &mut TxContext): ModifyDomain<C> {
+        ModifyDomain {
+            id: object::new(ctx),
+            generator: witness::generator(witness),
+        }
+    }
+
+    /// Adds domain of type `D` to `Nft`
+    ///
+    /// Allows users to independently register
+    ///
+    /// #### Panics
+    ///
+    /// - Transaction sender is not logical owner of the NFT
+    /// - `ModifyDomain` was not registered on `Collection`
+    /// - Domain `D` already exists on the `Nft`
+    public fun add_domain<C, D: key + store>(
+        collection: &Collection<C>,
+        nft: &mut Nft<C>,
+        domain: D,
+        ctx: &mut TxContext,
+    ) {
+        assert_owner(nft, ctx);
+        let modify_domain = borrow_modify_domain(collection);
+
+        nft::add_domain(
+            witness::delegate(&modify_domain.generator),
+            nft,
+            domain,
+        )
+    }
+
+    /// Adds `ModifyDomain` to `Collection`
+    ///
+    /// This allows users to independently add domains to their NFTs.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `ModifyDomain` already exists.
+    public fun add_modify_domain<C>(
+        witness: &C,
+        collection: &mut Collection<C>,
+        ctx: &mut TxContext,
+    ) {
+        let domain = new(witness, ctx);
+        collection::add_domain(
+            witness::from_witness(witness),
+            collection,
+            domain,
+        );
+    }
+
+    /// Borrows `ModifyDomain` from `Collection`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `ModifyDomain` is not registered on `Collection`.
+    fun borrow_modify_domain<C>(collection: &Collection<C>): &ModifyDomain<C> {
+        assert_domain(collection);
+        collection::borrow_domain(collection)
+    }
+
+    // === Assertions ===
+
+    /// Asserts that transaction sender is the logical owner of the NFT
+    ///
+    /// #### Panics
+    ///
+    /// Panics if transaction sender is not the logical owner of the NFT.
+    public fun assert_owner<C>(nft: &Nft<C>,  ctx: &mut TxContext) {
+        assert!(
+            tx_context::sender(ctx) == nft::logical_owner(nft),
+            EINVALID_LOGICAL_OWNER,
+        )
+    }
+
+    /// Asserts that `ModifyDomain` is defined on the `Collection`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `ModifyDomain` is not defined on the `Collection`.
+    public fun assert_domain<C>(collection: &Collection<C>) {
+        assert!(
+            collection::has_domain<C, ModifyDomain<C>>(collection),
+            EUNDEFINED_MODIFY_DOMAIN,
+        )
+    }
+}

--- a/sources/standards/modify.move
+++ b/sources/standards/modify.move
@@ -33,7 +33,7 @@ module nft_protocol::modify {
     }
 
     /// Creates a new `ModifyDomain`
-    fun new<C>(witness: &C, ctx: &mut TxContext): ModifyDomain<C> {
+    fun new<C, W>(witness: &W, ctx: &mut TxContext): ModifyDomain<C> {
         ModifyDomain {
             id: object::new(ctx),
             generator: witness::generator(witness),
@@ -72,14 +72,14 @@ module nft_protocol::modify {
     /// #### Panics
     ///
     /// Panics if `ModifyDomain` already exists.
-    public fun add_modify_domain<C>(
-        witness: &C,
+    public fun add_modify_domain<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         ctx: &mut TxContext,
     ) {
-        let domain = new(witness, ctx);
+        let domain = new<C, W>(witness, ctx);
         collection::add_domain(
-            witness::from_collection_witness(witness),
+            witness::from_witness(witness),
             collection,
             domain,
         );

--- a/sources/standards/plugins.move
+++ b/sources/standards/plugins.move
@@ -44,7 +44,7 @@ module nft_protocol::plugins {
     struct Witness has drop {}
 
     /// Creates a new `PluginDomain` object
-    fun new<C>(witness: &C, ctx: &mut TxContext): PluginDomain<C> {
+    fun new<C, W>(witness: &W, ctx: &mut TxContext): PluginDomain<C> {
         PluginDomain {
             id: object::new(ctx),
             generator: witness::generator(witness),
@@ -146,12 +146,12 @@ module nft_protocol::plugins {
     /// #### Panics
     ///
     /// Panics if `CreatorsDomain` already exists.
-    public fun add_plugin_domain<C>(
-        witness: &C,
+    public fun add_plugin_domain<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         ctx: &mut TxContext,
     ) {
-        let domain = new(witness, ctx);
+        let domain = new<C, W>(witness, ctx);
         collection::add_domain(
             witness::from_witness(witness),
             collection,

--- a/sources/standards/tags.move
+++ b/sources/standards/tags.move
@@ -137,11 +137,11 @@ module nft_protocol::tags {
     }
 
     public fun add_tag_domain<C>(
+        witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
         tags: TagDomain,
-        ctx: &mut TxContext,
     ) {
-        nft::add_domain(nft, tags, ctx);
+        nft::add_domain(witness, nft, tags);
     }
 
     public fun add_collection_tag_domain<C>(

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -1,18 +1,7 @@
 /// Exports error functions. All errors in this smart contract have a prefix
 /// which distinguishes them from errors in other packages.
 module nft_protocol::err {
-
     const Prefix: u64 = 13370000;
-
-    // === NFT & Collection ===
-
-    public fun not_nft_owner(): u64 {
-        return Prefix + 002
-    }
-
-    public fun mint_cap_mismatch(): u64 {
-        return Prefix + 003
-    }
 
     // === Supply ===
 
@@ -208,23 +197,5 @@ module nft_protocol::err {
 
     public fun share_attribution_already_exists(): u64 {
         return Prefix + 803
-    }
-
-    public fun collection_does_not_have_plugin(): u64 {
-        return Prefix + 804
-    }
-
-    // === Generic ===
-
-    public fun generic_bag_full(): u64 {
-        return Prefix + 900
-    }
-
-    public fun generic_box_full(): u64 {
-        return Prefix + 901
-    }
-
-    public fun missing_dynamic_field(): u64 {
-        return Prefix + 902
     }
 }

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -135,16 +135,6 @@ module nft_protocol::err {
         return Prefix + 410
     }
 
-    // === Allowlist ===
-
-    public fun authority_not_allowlisted(): u64 {
-        return Prefix + 500
-    }
-
-    public fun sender_not_allowlist_admin(): u64 {
-        return Prefix + 502
-    }
-
     // === Utils ===
 
     public fun witness_source_mismatch(): u64 {
@@ -153,22 +143,6 @@ module nft_protocol::err {
 
     public fun must_be_witness(): u64 {
         return Prefix + 601
-    }
-
-    public fun multisig_signers_must_not_be_empty(): u64 {
-        return Prefix + 602
-    }
-
-    public fun multisig_already_used(): u64 {
-        return Prefix + 603
-    }
-
-    public fun multisig_not_enough_signatures(): u64 {
-        return Prefix + 604
-    }
-
-    public fun multisig_not_enough_signers_weight(): u64 {
-        return Prefix + 605
     }
 
     // === Trading ===

--- a/tests/bidding/safe_to_safe_trade.move
+++ b/tests/bidding/safe_to_safe_trade.move
@@ -127,7 +127,7 @@ module nft_protocol::test_bidding_safe_to_safe_trade {
         let royalty = royalty::from_address(CREATOR, ctx(&mut scenario));
         royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain<Foo>(
-            witness::from_witness(&Foo {}), &mut collection, royalty
+            witness::from_witness(&Witness {}), &mut collection, royalty,
         );
 
         // If domain does not exist this function call will fail

--- a/tests/domains/creators.move
+++ b/tests/domains/creators.move
@@ -8,6 +8,7 @@ module nft_protocol::test_creators {
     use nft_protocol::collection;
 
     struct Foo has drop {}
+    struct Witness has drop {}
 
     const CREATOR: address = @0xA1C04;
 
@@ -19,9 +20,11 @@ module nft_protocol::test_creators {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         collection::add_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut collection,
-            creators::from_address(&Foo {}, CREATOR, ctx(&mut scenario)),
+            creators::from_address<Foo, Witness>(
+                &Witness {}, CREATOR, ctx(&mut scenario),
+            ),
         );
         creators::assert_domain(&collection);
 

--- a/tests/domains/display.move
+++ b/tests/domains/display.move
@@ -26,6 +26,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_display_domain(
+            witness::from_witness(&Foo {}),
             &mut nft,
             string::utf8(b"Suimarines-234"),
             string::utf8(b"Collection of Suimarines"),
@@ -70,6 +71,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_url_domain(
+            witness::from_witness(&Foo {}),
             &mut nft,
             url::new_unsafe_from_bytes(b"https://originbyte.io/"),
             ctx(&mut scenario),
@@ -112,6 +114,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_symbol_domain(
+            witness::from_witness(&Foo {}),
             &mut nft,
             string::utf8(b"SUIM-234"),
             ctx
@@ -160,6 +163,7 @@ module nft_protocol::test_display {
         );
 
         display::add_attributes_domain(
+            witness::from_witness(&Foo {}),
             &mut nft,
             attributes,
             ctx

--- a/tests/domains/display.move
+++ b/tests/domains/display.move
@@ -15,6 +15,7 @@ module nft_protocol::test_display {
     };
 
     struct Foo has drop {}
+    struct Witness has drop {}
 
     const CREATOR: address = @0xA1C04;
 
@@ -26,7 +27,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_display_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             string::utf8(b"Suimarines-234"),
             string::utf8(b"Collection of Suimarines"),
@@ -48,7 +49,7 @@ module nft_protocol::test_display {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         display::add_collection_display_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut collection,
             string::utf8(b"Suimarines-234"),
             string::utf8(b"Collection of Suimarines"),
@@ -71,7 +72,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_url_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             url::new_unsafe_from_bytes(b"https://originbyte.io/"),
             ctx(&mut scenario),
@@ -92,7 +93,7 @@ module nft_protocol::test_display {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         display::add_collection_url_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut collection,
             url::new_unsafe_from_bytes(b"https://originbyte.io/"),
             ctx(&mut scenario)
@@ -114,7 +115,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_symbol_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             string::utf8(b"SUIM-234"),
             ctx
@@ -135,7 +136,7 @@ module nft_protocol::test_display {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         display::add_collection_symbol_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut collection,
             string::utf8(b"SUIM"),
             ctx(&mut scenario)
@@ -163,7 +164,7 @@ module nft_protocol::test_display {
         );
 
         display::add_attributes_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             attributes,
             ctx

--- a/tests/domains/royalty.move
+++ b/tests/domains/royalty.move
@@ -8,6 +8,7 @@ module nft_protocol::test_royalty {
     use nft_protocol::royalty::{Self, RoyaltyDomain};
 
     struct Foo has drop {}
+    struct Witness has drop {}
 
     const CREATOR: address = @0xA1C04;
 
@@ -22,7 +23,7 @@ module nft_protocol::test_royalty {
         royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_constant_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut collection,
             royalty,
         );

--- a/tests/domains/tags.move
+++ b/tests/domains/tags.move
@@ -25,7 +25,7 @@ module nft_protocol::test_tags {
         tags::add_tag(&mut tags, tags::profile_picture());
 
         tags::add_tag_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             tags,
         );
@@ -53,7 +53,7 @@ module nft_protocol::test_tags {
         tags::add_tag(&mut tags, tags::game_asset());
 
         tags::add_collection_tag_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut collection,
             tags,
         );

--- a/tests/domains/tags.move
+++ b/tests/domains/tags.move
@@ -25,9 +25,9 @@ module nft_protocol::test_tags {
         tags::add_tag(&mut tags, tags::profile_picture());
 
         tags::add_tag_domain(
+            witness::from_witness(&Foo {}),
             &mut nft,
             tags,
-            ctx
         );
 
         // If domain does not exist this function call will fail

--- a/tests/market/dutch_auction.move
+++ b/tests/market/dutch_auction.move
@@ -11,7 +11,7 @@ module nft_protocol::test_dutch_auction {
 
     use originmate::crit_bit_u64 as crit_bit;
 
-    use nft_protocol::nft;
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::witness;
     use nft_protocol::proceeds;
     use nft_protocol::venue;
@@ -595,6 +595,8 @@ module nft_protocol::test_dutch_auction {
 
         listing::sale_on(&mut listing, venue_id, ctx(&mut scenario));
 
+        test_scenario::next_tx(&mut scenario, BUYER);
+
         let wallet = coin::mint_for_testing<SUI>(35, ctx(&mut scenario));
 
         dutch_auction::create_bid(
@@ -624,6 +626,8 @@ module nft_protocol::test_dutch_auction {
             ctx(&mut scenario),
         );
 
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
         dutch_auction::sale_conclude<COLLECTION, SUI>(
             &mut listing,
             venue_id,
@@ -648,18 +652,27 @@ module nft_protocol::test_dutch_auction {
         // One bid should have been refunded and also some change
         let refunded0 = test_scenario::take_from_address<Coin<SUI>>(
             &scenario,
-            CREATOR,
+            BUYER,
         );
         assert!(coin::value(&refunded0) == 10, 0);
 
         let refunded1 = test_scenario::take_from_address<Coin<SUI>>(
             &scenario,
-            CREATOR,
+            BUYER,
         );
         assert!(coin::value(&refunded1) == 1, 0);
 
-        test_scenario::return_to_address(CREATOR, refunded0);
-        test_scenario::return_to_address(CREATOR, refunded1);
+        test_scenario::return_to_address(BUYER, refunded0);
+        test_scenario::return_to_address(BUYER, refunded1);
+
+        // Check NFT was transferred with correct logical owner
+        let nft = test_scenario::take_from_address<Nft<COLLECTION>>(
+            &scenario, BUYER
+        );
+
+        assert!(nft::logical_owner(&nft) == BUYER, 0);
+
+        test_scenario::return_to_address(BUYER, nft);
 
         // Check bid state
         let market = venue::borrow_market(venue);

--- a/tests/market/dutch_auction.move
+++ b/tests/market/dutch_auction.move
@@ -12,6 +12,7 @@ module nft_protocol::test_dutch_auction {
     use originmate::crit_bit_u64 as crit_bit;
 
     use nft_protocol::nft;
+    use nft_protocol::witness;
     use nft_protocol::proceeds;
     use nft_protocol::venue;
     use nft_protocol::listing::{Self, Listing};
@@ -34,7 +35,7 @@ module nft_protocol::test_dutch_auction {
         scenario: &mut Scenario,
     ): (ID, ID) {
         let inventory_id = listing::create_warehouse<COLLECTION>(
-            listing, ctx(scenario)
+            witness::from_witness(&Witness {}), listing, ctx(scenario)
         );
         let venue_id = dutch_auction::create_venue<COLLECTION, SUI>(
             listing, inventory_id, is_whitelisted, reserve_price, ctx(scenario)

--- a/tests/market/fixed_price.move
+++ b/tests/market/fixed_price.move
@@ -8,6 +8,7 @@ module nft_protocol::test_fixed_price {
 
     use nft_protocol::nft;
     use nft_protocol::venue;
+    use nft_protocol::witness;
     use nft_protocol::warehouse;
     use nft_protocol::listing::{Self, Listing};
     use nft_protocol::market_whitelist::{Self, Certificate};
@@ -30,7 +31,7 @@ module nft_protocol::test_fixed_price {
         scenario: &mut Scenario,
     ): (ID, ID) {
         let inventory_id = listing::create_warehouse<COLLECTION>(
-            listing, ctx(scenario),
+            witness::from_witness(&Witness {}), listing, ctx(scenario),
         );
         let venue_id = fixed_price::create_venue<COLLECTION, SUI>(
             listing, inventory_id, is_whitelisted, price, ctx(scenario)

--- a/tests/market/fixed_price.move
+++ b/tests/market/fixed_price.move
@@ -2,13 +2,15 @@
 module nft_protocol::test_fixed_price {
     use sui::sui::SUI;
     use sui::coin;
+    use sui::balance;
     use sui::transfer;
     use sui::object::ID;
     use sui::test_scenario::{Self, Scenario, ctx};
 
-    use nft_protocol::nft;
+    use nft_protocol::nft::{Self, Nft};
     use nft_protocol::venue;
     use nft_protocol::witness;
+    use nft_protocol::proceeds;
     use nft_protocol::warehouse;
     use nft_protocol::listing::{Self, Listing};
     use nft_protocol::market_whitelist::{Self, Certificate};
@@ -122,6 +124,7 @@ module nft_protocol::test_fixed_price {
         test_scenario::next_tx(&mut scenario, BUYER);
 
         let wallet = coin::mint_for_testing<SUI>(15, ctx(&mut scenario));
+
         fixed_price::buy_nft<COLLECTION, SUI>(
             &mut listing,
             venue_id,
@@ -129,11 +132,26 @@ module nft_protocol::test_fixed_price {
             ctx(&mut scenario),
         );
 
+        test_scenario::next_tx(&mut scenario, CREATOR);
+
+        // Check wallet balances
         assert!(coin::value(&wallet) == 5, 0);
 
-        transfer::transfer(wallet, BUYER);
-        test_scenario::next_tx(&mut scenario, BUYER);
+        // Nft should have sold at 10
+        let proceeds = listing::borrow_proceeds(&listing);
+        assert!(proceeds::total(proceeds) == 1, 0);
+        assert!(balance::value(proceeds::balance<SUI>(proceeds)) == 10, 0);
 
+        // Check NFT was transferred with correct logical owner
+        let nft = test_scenario::take_from_address<Nft<COLLECTION>>(
+            &scenario, BUYER
+        );
+
+        assert!(nft::logical_owner(&nft) == BUYER, 0);
+
+        test_scenario::return_to_address(BUYER, nft);
+
+        transfer::transfer(wallet, BUYER);
         test_scenario::return_shared(listing);
         test_scenario::end(scenario);
     }

--- a/tests/mint_and_sell.move
+++ b/tests/mint_and_sell.move
@@ -43,7 +43,8 @@ module nft_protocol::mint_and_sell {
         listing::sale_on(&mut listing, venue_id, ctx(&mut scenario));
 
         // 3. Mint NFT to listing `Warehouse`
-        let nft = nft::new(&mint_cap, MARKETPLACE, ctx(&mut scenario));
+        let nft =
+            nft::new(&Witness {}, &mint_cap, MARKETPLACE, ctx(&mut scenario));
 
         let nft_id = object::id(&nft);
         listing::add_nft(&mut listing, inventory_id, nft, ctx(&mut scenario));
@@ -89,7 +90,8 @@ module nft_protocol::mint_and_sell {
         let warehouse = warehouse::new(ctx(&mut scenario));
 
         // 3. Mint NFT to `Warehouse`
-        let nft = nft::new(&mint_cap, MARKETPLACE, ctx(&mut scenario));
+        let nft =
+            nft::new(&Witness {}, &mint_cap, MARKETPLACE, ctx(&mut scenario));
 
         let nft_id = object::id(&nft);
         warehouse::deposit_nft(&mut warehouse, nft);

--- a/tests/mint_and_sell.move
+++ b/tests/mint_and_sell.move
@@ -35,7 +35,9 @@ module nft_protocol::mint_and_sell {
 
         // 2. Create `Warehouse`
         let inventory_id = listing::create_warehouse<COLLECTION>(
-            witness::from_witness(&Witness {}), &mut listing, ctx(&mut scenario)
+            witness::from_witness(&Witness {}),
+            &mut listing,
+            ctx(&mut scenario),
         );
         let venue_id = fixed_price::create_venue<COLLECTION, SUI>(
             &mut listing, inventory_id, false, 100, ctx(&mut scenario)
@@ -44,7 +46,7 @@ module nft_protocol::mint_and_sell {
 
         // 3. Mint NFT to listing `Warehouse`
         let nft =
-            nft::new(&Witness {}, &mint_cap, MARKETPLACE, ctx(&mut scenario));
+            nft::from_mint_cap(&mint_cap, MARKETPLACE, ctx(&mut scenario));
 
         let nft_id = object::id(&nft);
         listing::add_nft(&mut listing, inventory_id, nft, ctx(&mut scenario));
@@ -91,7 +93,7 @@ module nft_protocol::mint_and_sell {
 
         // 3. Mint NFT to `Warehouse`
         let nft =
-            nft::new(&Witness {}, &mint_cap, MARKETPLACE, ctx(&mut scenario));
+            nft::from_mint_cap(&mint_cap, MARKETPLACE, ctx(&mut scenario));
 
         let nft_id = object::id(&nft);
         warehouse::deposit_nft(&mut warehouse, nft);

--- a/tests/mint_and_sell.move
+++ b/tests/mint_and_sell.move
@@ -6,12 +6,12 @@ module nft_protocol::mint_and_sell {
     use sui::transfer;
     use sui::test_scenario::{Self, ctx};
 
+    use nft_protocol::witness;
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::fixed_price;
     use nft_protocol::collection;
     use nft_protocol::listing;
     use nft_protocol::warehouse;
-    use nft_protocol::inventory;
 
     use nft_protocol::test_listing;
 
@@ -35,7 +35,7 @@ module nft_protocol::mint_and_sell {
 
         // 2. Create `Warehouse`
         let inventory_id = listing::create_warehouse<COLLECTION>(
-            &mut listing, ctx(&mut scenario)
+            witness::from_witness(&Witness {}), &mut listing, ctx(&mut scenario)
         );
         let venue_id = fixed_price::create_venue<COLLECTION, SUI>(
             &mut listing, inventory_id, false, 100, ctx(&mut scenario)
@@ -95,9 +95,14 @@ module nft_protocol::mint_and_sell {
         warehouse::deposit_nft(&mut warehouse, nft);
 
         // 4. Insert `Warehouse` into `Listing` and create market
-        let inventory = inventory::from_warehouse(warehouse, ctx(&mut scenario));
-        let inventory_id = object::id(&inventory);
-        listing::add_inventory(&mut listing, inventory, ctx(&mut scenario));
+        //
+        // For an entry function equivalent use `listing::add_warehouse`
+        let inventory_id = listing::insert_warehouse(
+            witness::from_witness(&Witness {}),
+            &mut listing,
+            warehouse,
+            ctx(&mut scenario)
+        );
 
         let venue_id = fixed_price::create_venue<COLLECTION, SUI>(
             &mut listing, inventory_id, false, 100, ctx(&mut scenario)

--- a/tests/nft.move
+++ b/tests/nft.move
@@ -10,6 +10,7 @@ module nft_protocol::fake_witness {
 
 #[test_only]
 module nft_protocol::test_nft {
+    use nft_protocol::witness;
     use nft_protocol::fake_witness::{Self, FakeWitness};
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::utils;
@@ -48,7 +49,11 @@ module nft_protocol::test_nft {
 
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
-        nft::add_domain(&mut nft, DomainA { id: object::new(ctx) }, ctx);
+        nft::add_domain(
+            witness::from_witness(&Foo {}),
+            &mut nft,
+            DomainA { id: object::new(ctx) },
+        );
 
         // If domain does not exist this function call will fail
         nft::borrow_domain<Foo, DomainA>(&nft);
@@ -64,7 +69,11 @@ module nft_protocol::test_nft {
 
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
-        nft::add_domain(&mut nft, DomainA { id: object::new(ctx) }, ctx);
+        nft::add_domain(
+            witness::from_witness(&Foo {}),
+            &mut nft,
+            DomainA { id: object::new(ctx) },
+        );
 
         nft::borrow_domain_mut<Foo, DomainA, Witness>(
             Witness {}, &mut nft
@@ -82,24 +91,18 @@ module nft_protocol::test_nft {
 
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
-        nft::add_domain(&mut nft, DomainA { id: object::new(ctx) }, ctx);
+        nft::add_domain(
+            witness::from_witness(&Foo {}),
+            &mut nft,
+            DomainA { id: object::new(ctx) },
+        );
 
         // This second call will fail
-        nft::add_domain(&mut nft, DomainA { id: object::new(ctx) }, ctx);
-
-        transfer(nft, OWNER);
-        test_scenario::end(scenario);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = 13370002, location = nft_protocol::nft)]
-    fun fails_adding_domain_if_not_owner() {
-        let scenario = test_scenario::begin(FAKE_OWNER);
-        let ctx = ctx(&mut scenario);
-
-        let nft = nft::test_mint<Foo>(OWNER, ctx);
-
-        nft::add_domain(&mut nft, DomainA { id: object::new(ctx) }, ctx);
+        nft::add_domain(
+            witness::from_witness(&Foo {}),
+            &mut nft,
+            DomainA { id: object::new(ctx) },
+        );
 
         transfer(nft, OWNER);
         test_scenario::end(scenario);
@@ -113,7 +116,11 @@ module nft_protocol::test_nft {
 
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
-        nft::add_domain(&mut nft, DomainA { id: object::new(ctx) }, ctx);
+        nft::add_domain(
+            witness::from_witness(&Foo {}),
+            &mut nft,
+            DomainA { id: object::new(ctx) },
+        );
 
         nft::borrow_domain<Foo, DomainA>(&nft);
         nft::borrow_domain_mut<Foo, DomainA, FakeWitness>(

--- a/tests/nft.move
+++ b/tests/nft.move
@@ -50,7 +50,7 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
@@ -70,7 +70,7 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
@@ -92,14 +92,14 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
 
         // This second call will fail
         nft::add_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
@@ -117,7 +117,7 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Foo {}),
+            witness::from_witness(&Witness {}),
             &mut nft,
             DomainA { id: object::new(ctx) },
         );

--- a/tests/safe.move
+++ b/tests/safe.move
@@ -1,5 +1,6 @@
 #[test_only]
 module nft_protocol::test_safe {
+    use nft_protocol::witness;
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::safe::{Self, Safe, OwnerCap};
     use nft_protocol::transfer_allowlist::{Self, Allowlist};
@@ -11,6 +12,7 @@ module nft_protocol::test_safe {
     use originmate::box;
 
     struct Foo {}
+
     struct Witness has drop {}
 
     const USER: address = @0xA1C04;
@@ -922,17 +924,13 @@ module nft_protocol::test_safe {
     }
 
     fun dummy_allowlist(scenario: &mut Scenario): Allowlist {
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(scenario),
-        );
-
         let wl = transfer_allowlist::create(&Witness {}, ctx(scenario));
+
         transfer_allowlist::insert_collection(
             &Witness {},
-            &col_cap,
+            witness::from_witness<Foo, Witness>(&Witness {}),
             &mut wl,
         );
-        transfer(col_cap, USER);
 
         wl
     }

--- a/tests/transfer_allowlist.move
+++ b/tests/transfer_allowlist.move
@@ -1,8 +1,10 @@
 #[test_only]
 module nft_protocol::test_transfer_allowlist {
-    use nft_protocol::transfer_allowlist;
     use sui::transfer::transfer;
-    use sui::test_scenario::{Self, ctx};
+    use sui::test_scenario::{Self, Scenario, ctx};
+
+    use nft_protocol::witness;
+    use nft_protocol::transfer_allowlist;
 
     struct Witness has drop {}
     struct Witness2 has drop {}
@@ -13,43 +15,38 @@ module nft_protocol::test_transfer_allowlist {
     const ADMIN: address = @0xA1C04;
     const CREATOR: address = @0xA1C05;
 
-    #[test]
-    #[expected_failure(abort_code = 13370601, location = nft_protocol::utils)]
-    fun it_cannot_create_collection_control_cap_if_witness_mismatches() {
-        let scenario = test_scenario::begin(ADMIN);
-
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness2>(
-            &Witness2 {}, ctx(&mut scenario),
-        );
-
-        transfer(col_cap, CREATOR);
-        test_scenario::end(scenario);
+    fun create_collection_cap<C>(
+        scenario: &mut Scenario,
+    ): transfer_allowlist::CollectionControlCap<C> {
+        transfer_allowlist::create_collection_cap(
+            witness::from_witness(&Witness {}), ctx(scenario),
+        )
     }
 
     #[test]
     fun it_allows_collection_to_remove_itself() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap,
+            col_cap,
             &mut wl,
         );
 
-        assert!(transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+        transfer_allowlist::assert_transferable<Foo, Witness>(&wl);
+        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(&wl), 0);
+
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         transfer_allowlist::remove_itself(&col_cap, &mut wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
 
         transfer(wl, ADMIN);
         transfer(col_cap, CREATOR);
@@ -57,52 +54,46 @@ module nft_protocol::test_transfer_allowlist {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370502, location = nft_protocol::transfer_allowlist)]
+    #[expected_failure(abort_code = transfer_allowlist::EINVALID_ADMIN)]
     fun it_fails_to_insert_collection_if_witness_mismatches() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness2 {},
-            &col_cap,
+            col_cap,
             &mut wl,
         );
 
         transfer(wl, ADMIN);
-        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370502, location = nft_protocol::transfer_allowlist)]
+    #[expected_failure(abort_code = transfer_allowlist::EINVALID_ADMIN)]
     fun it_fails_remove_collection_as_admin_if_witness_mismatches() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap,
+            col_cap,
             &mut wl,
         );
 
         transfer_allowlist::remove_collection<Witness2, Foo>(Witness2 {}, &mut wl);
 
         transfer(wl, ADMIN);
-        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -110,50 +101,46 @@ module nft_protocol::test_transfer_allowlist {
     fun it_removes_collection_as_admin() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap1 = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
-        let col_cap2 = transfer_allowlist::create_collection_cap<Bar, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap1 = create_collection_cap<Foo>(&mut scenario);
+        let col_cap2 = create_collection_cap<Bar>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap1,
+            col_cap1,
             &mut wl,
         );
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap2,
+            col_cap2,
             &mut wl,
         );
 
-        assert!(transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(transfer_allowlist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+        transfer_allowlist::assert_transferable<Foo, Witness>(&wl);
+        transfer_allowlist::assert_transferable<Bar, Witness>(&wl);
 
         transfer_allowlist::remove_collection<Witness, Foo>(Witness {}, &mut wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(transfer_allowlist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
+        transfer_allowlist::assert_transferable<Bar, Witness>(&wl);
 
-        transfer_allowlist::insert_collection(
+        let col_cap1 = create_collection_cap<Foo>(&mut scenario);
+
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap1,
+            col_cap1,
             &mut wl,
         );
 
         transfer_allowlist::clear_collections(Witness {}, &mut wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(&wl), 0);
 
         transfer(wl, ADMIN);
-        transfer(col_cap1, CREATOR);
-        transfer(col_cap2, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -161,35 +148,32 @@ module nft_protocol::test_transfer_allowlist {
     fun it_inserts_authority() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap,
+            col_cap,
             &mut wl,
         );
 
         transfer_allowlist::insert_authority<Witness, Witness2>(Witness {}, &mut wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(transfer_allowlist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
+        transfer_allowlist::assert_transferable<Foo, Witness2>(&wl);
 
         transfer_allowlist::insert_authority<Witness, Witness>(Witness {}, &mut wl);
 
-        assert!(transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(transfer_allowlist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+        transfer_allowlist::assert_transferable<Foo, Witness>(&wl);
+        transfer_allowlist::assert_transferable<Foo, Witness2>(&wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(Witness {}, &wl), 0);
-        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness2>(Witness2 {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(&wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Bar, Witness2>(&wl), 0);
 
         transfer(wl, ADMIN);
-        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -197,37 +181,34 @@ module nft_protocol::test_transfer_allowlist {
     fun it_removes_authority() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap,
+            col_cap,
             &mut wl,
         );
 
         transfer_allowlist::insert_authority<Witness, Witness2>(Witness {}, &mut wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(transfer_allowlist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
+        transfer_allowlist::assert_transferable<Foo, Witness2>(&wl);
 
         transfer_allowlist::remove_authority<Witness, Witness2>(Witness {}, &mut wl);
 
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(Witness {}, &wl), 0);
-        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness2>(Witness2 {}, &wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
+        assert!(!transfer_allowlist::can_be_transferred<Foo, Witness2>(&wl), 0);
 
         transfer(wl, ADMIN);
-        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370502, location = nft_protocol::transfer_allowlist)]
+    #[expected_failure(abort_code = transfer_allowlist::EINVALID_ADMIN)]
     fun it_fails_to_insert_authority_if_witness_mismatches() {
         let scenario = test_scenario::begin(ADMIN);
 
@@ -241,7 +222,7 @@ module nft_protocol::test_transfer_allowlist {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370502, location = nft_protocol::transfer_allowlist)]
+    #[expected_failure(abort_code = transfer_allowlist::EINVALID_ADMIN)]
     fun it_fails_to_remove_authority_if_witness_mismatches() {
         let scenario = test_scenario::begin(ADMIN);
 
@@ -256,28 +237,25 @@ module nft_protocol::test_transfer_allowlist {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370502, location = nft_protocol::transfer_allowlist)]
+    #[expected_failure(abort_code = transfer_allowlist::EINVALID_ADMIN)]
     fun it_fails_to_clear_collections_if_witness_mismatches() {
         let scenario = test_scenario::begin(ADMIN);
 
-        let col_cap = transfer_allowlist::create_collection_cap<Foo, Witness>(
-            &Witness {}, ctx(&mut scenario),
-        );
+        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         test_scenario::next_tx(&mut scenario, ADMIN);
         let wl = transfer_allowlist::create(&Witness {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, CREATOR);
-        transfer_allowlist::insert_collection(
+        transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            &col_cap,
+            col_cap,
             &mut wl,
         );
 
         transfer_allowlist::clear_collections(Witness2 {}, &mut wl);
 
         transfer(wl, ADMIN);
-        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 }

--- a/tests/transfer_allowlist.move
+++ b/tests/transfer_allowlist.move
@@ -35,14 +35,12 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap,
+            &col_cap,
             &mut wl,
         );
 
         transfer_allowlist::assert_transferable<Foo, Witness>(&wl);
         assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(&wl), 0);
-
-        let col_cap = create_collection_cap<Foo>(&mut scenario);
 
         transfer_allowlist::remove_itself(&col_cap, &mut wl);
 
@@ -66,11 +64,12 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness2 {},
-            col_cap,
+            &col_cap,
             &mut wl,
         );
 
         transfer(wl, ADMIN);
+        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -87,13 +86,14 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap,
+            &col_cap,
             &mut wl,
         );
 
         transfer_allowlist::remove_collection<Witness2, Foo>(Witness2 {}, &mut wl);
 
         transfer(wl, ADMIN);
+        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -110,12 +110,12 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap1,
+            &col_cap1,
             &mut wl,
         );
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap2,
+            &col_cap2,
             &mut wl,
         );
 
@@ -127,11 +127,9 @@ module nft_protocol::test_transfer_allowlist {
         assert!(!transfer_allowlist::can_be_transferred<Foo, Witness>(&wl), 0);
         transfer_allowlist::assert_transferable<Bar, Witness>(&wl);
 
-        let col_cap1 = create_collection_cap<Foo>(&mut scenario);
-
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap1,
+            &col_cap1,
             &mut wl,
         );
 
@@ -141,6 +139,8 @@ module nft_protocol::test_transfer_allowlist {
         assert!(!transfer_allowlist::can_be_transferred<Bar, Witness>(&wl), 0);
 
         transfer(wl, ADMIN);
+        transfer(col_cap1, CREATOR);
+        transfer(col_cap2, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -156,7 +156,7 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap,
+            &col_cap,
             &mut wl,
         );
 
@@ -174,6 +174,7 @@ module nft_protocol::test_transfer_allowlist {
         assert!(!transfer_allowlist::can_be_transferred<Bar, Witness2>(&wl), 0);
 
         transfer(wl, ADMIN);
+        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -189,7 +190,7 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap,
+            &col_cap,
             &mut wl,
         );
 
@@ -204,6 +205,7 @@ module nft_protocol::test_transfer_allowlist {
         assert!(!transfer_allowlist::can_be_transferred<Foo, Witness2>(&wl), 0);
 
         transfer(wl, ADMIN);
+        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 
@@ -249,13 +251,14 @@ module nft_protocol::test_transfer_allowlist {
         test_scenario::next_tx(&mut scenario, CREATOR);
         transfer_allowlist::insert_collection_with_cap(
             &Witness {},
-            col_cap,
+            &col_cap,
             &mut wl,
         );
 
         transfer_allowlist::clear_collections(Witness2 {}, &mut wl);
 
         transfer(wl, ADMIN);
+        transfer(col_cap, CREATOR);
         test_scenario::end(scenario);
     }
 }


### PR DESCRIPTION
PR brings NFT permissions inline with `DelegatedWitness` changes and loose NFT minting.

In effect this leaves our permission system in the following state:

- `DelegatedWitness`
    - May add `Collection` and NFT domains
    - May modify standard domains
- `MintCap`
    - May mint NFT
    - May delegate creation of `RegulatedMintCap` and `UnregulatedMintCap`
    - May add domains to NFT but only with original contract `Witness`
        - This is so `MintCap` may be safely shared
- `UnregulatedMintCap`
    - May mint NFT
    - May add domains to NFT only if transaction sender is also `logical_owner`
    - May be transposed to `RegulatedMintCap`
- `RegulatedMintCap`
    - May mint NFT
    - May add domains to NFT only if transaction sender is also `logical_owner`
- `logical_owner`
    - May add domains to NFT if `ModifyDomain` exists
    
Additionally, `Inventory` now safely changes the `logical_owner` of redeemed NFTs using an embedded `Allowlist`. 
