### PR TITLE
We no longer use Bag because it's RPC unfriendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2023-02-02
+
+### Changed
+
+- `TagsDomain` now uses dynamic fields instead of `Bag`.
+- `RoyaltyDomain` now uses dynamic fields instead of `Bag`.
+
 ## [0.20.3] - 2023-01-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.21.0] - 2023-02-02
+### Unreleased
 
 ### Changed
 
+- Renamed `CollectionMintEvent` to `MintCollectionEvent` to be consistent with
+  `MintNftEvent`.
 - `TagsDomain` now uses dynamic fields instead of `Bag`.
 - `RoyaltyDomain` now uses dynamic fields instead of `Bag`.
 

--- a/Move.toml
+++ b/Move.toml
@@ -14,4 +14,4 @@ git = "https://github.com/Origin-Byte/originmate.git"
 rev = "6f599cffa5199edf8dedbdbbe6e4d2a04b576e83"
 
 [addresses]
-nft_protocol = "0x0"
+nft_protocol = "0x"

--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "NftProtocol"
-version = "0.20.3"
+version = "0.21.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
@@ -14,4 +14,4 @@ git = "https://github.com/Origin-Byte/originmate.git"
 rev = "6f599cffa5199edf8dedbdbbe6e4d2a04b576e83"
 
 [addresses]
-nft_protocol = "0x"
+nft_protocol = "0x0"

--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "NftProtocol"
-version = "0.21.0"
+version = "0.20.3"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sources/collection/collection.move
+++ b/sources/collection/collection.move
@@ -51,7 +51,7 @@ module nft_protocol::collection {
     }
 
     /// Event signalling that a `Collection` was minted
-    struct CollectionMintEvent has copy, drop {
+    struct MintCollectionEvent has copy, drop {
         /// ID of the `Collection` that was minted
         collection_id: ID,
         /// Type name of `Collection<C>` one-time witness `C`
@@ -77,7 +77,7 @@ module nft_protocol::collection {
     ): (MintCap<C>, Collection<C>) {
         let id = object::new(ctx);
 
-        event::emit(CollectionMintEvent {
+        event::emit(MintCollectionEvent {
             collection_id: object::uid_to_inner(&id),
             type_name: type_name::get<C>(),
         });

--- a/sources/standards/royalties/royalty.move
+++ b/sources/standards/royalties/royalty.move
@@ -17,7 +17,6 @@ module nft_protocol::royalty {
     use sui::transfer;
     use sui::balance::{Self, Balance};
     use sui::tx_context::{Self, TxContext};
-    // use sui::bag::{Self, Bag};
     use sui::dynamic_field as df;
     use sui::vec_map::{Self, VecMap};
     use sui::object::{Self, UID};

--- a/sources/standards/tags.move
+++ b/sources/standards/tags.move
@@ -6,7 +6,7 @@ module nft_protocol::tags {
     // TODO: Consider if we should add a wrapper domain Tags {bag} such that
     // wallet can always query this domain instead of having to query all domains
     // and figure out which ones are tags or not.
-    use sui::bag::{Self, Bag};
+    use sui::dynamic_field as df;
     use sui::object::{Self, UID};
     use sui::tx_context::{Self, TxContext};
 
@@ -83,19 +83,18 @@ module nft_protocol::tags {
 
     struct TagDomain has key, store {
         id: UID,
-        bag: Bag,
     }
 
     /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
     public fun empty(ctx: &mut TxContext): TagDomain {
-        TagDomain { id: object::new(ctx), bag: bag::new(ctx) }
+        TagDomain { id: object::new(ctx) }
     }
 
     public fun has_tag<T: store + drop>(domain: &TagDomain): bool {
         utils::assert_same_module_as_witness<T, Witness>();
-        bag::contains_with_type<Marker<T>, T>(&domain.bag, utils::marker<T>())
+        df::exists_with_type<Marker<T>, T>(&domain.id, utils::marker<T>())
     }
 
     /// Adds tag to `TagDomain`
@@ -104,7 +103,7 @@ module nft_protocol::tags {
         tag: T,
     ) {
         utils::assert_same_module_as_witness<T, Witness>();
-        bag::add(&mut domain.bag, utils::marker<T>(), tag)
+        df::add(&mut domain.id, utils::marker<T>(), tag)
     }
 
     /// Removes tag from `TagDomain`
@@ -112,7 +111,7 @@ module nft_protocol::tags {
         domain: &mut TagDomain,
     ) {
         utils::assert_same_module_as_witness<T, Witness>();
-        let _: T = bag::remove(&mut domain.bag, utils::marker<T>());
+        let _: T = df::remove(&mut domain.id, utils::marker<T>());
     }
 
     // ====== Interoperability ===


### PR DESCRIPTION

## [0.21.0] - 2023-02-02

### Changed

- `TagsDomain` now uses dynamic fields instead of `Bag`.
- `RoyaltyDomain` now uses dynamic fields instead of `Bag`.
