### PR TITLE
Listing NFTs in orderbook creates a transfer cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `orderbook::list_nft` and `orderbook::list_nft_with_commission` endpoints.
+  These allow the client to skip the creation of transfer caps and instead
+  provide `OwnerCap` to `Safe` directly to the orderbook contract.
+
 ## [0.22.0] - 2023-02-02
 
 ### Added
 
 - Introduced `DelegatedWitness` pattern
 - Refactored `CreatorsDomain` to support `DelegatedWitness` and introduced `PluginDomain`
+
 ### Changed
 
 - Renamed `CollectionMintEvent` to `MintCollectionEvent` to be consistent with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Added
 
 - `orderbook::list_nft` and `orderbook::list_nft_with_commission` endpoints.
-  These allow the client to skip the creation of transfer caps and instead
-  provide `OwnerCap` to `Safe` directly to the orderbook contract.
+  These allow the client to skip the creation of transfer caps and instead provide `OwnerCap` to `Safe` directly to the orderbook contract.
 
 ## [0.22.0] - 2023-02-02
 

--- a/sources/trading/orderbook.move
+++ b/sources/trading/orderbook.move
@@ -339,6 +339,25 @@ module nft_protocol::orderbook {
         )
     }
 
+    /// Creates exclusive transfer cap and then calls [`create_ask`].
+    public entry fun list_nft<C, FT>(
+        book: &mut Orderbook<C, FT>,
+        requested_tokens: u64,
+        nft: ID,
+        owner_cap: &safe::OwnerCap,
+        seller_safe: &mut Safe,
+        ctx: &mut TxContext,
+    ) {
+        let transfer_cap = safe::create_exclusive_transfer_cap(
+            nft,
+            owner_cap,
+            seller_safe,
+            ctx,
+        );
+
+        create_ask(book, requested_tokens, transfer_cap, seller_safe, ctx)
+    }
+
     /// Same as [`create_ask`] but protected by
     /// [collection witness](https://docs.originbyte.io/origin-byte/about-our-programs/liquidity-layer/orderbook#witness-protected-actions).
     public fun create_ask_protected<W: drop, C, FT>(
@@ -379,6 +398,36 @@ module nft_protocol::orderbook {
             requested_tokens,
             option::some(commission),
             transfer_cap,
+            seller_safe,
+            ctx,
+        )
+    }
+
+    /// Creates exclusive transfer cap and then calls
+    /// [`create_ask_with_commission`].
+    public entry fun list_nft_with_commission<C, FT>(
+        book: &mut Orderbook<C, FT>,
+        requested_tokens: u64,
+        nft: ID,
+        owner_cap: &safe::OwnerCap,
+        beneficiary: address,
+        commission: u64,
+        seller_safe: &mut Safe,
+        ctx: &mut TxContext,
+    ) {
+        let transfer_cap = safe::create_exclusive_transfer_cap(
+            nft,
+            owner_cap,
+            seller_safe,
+            ctx,
+        );
+
+        create_ask_with_commission(
+            book,
+            requested_tokens,
+            transfer_cap,
+            beneficiary,
+            commission,
             seller_safe,
             ctx,
         )

--- a/tests/orderbook/commission.move
+++ b/tests/orderbook/commission.move
@@ -3,8 +3,11 @@ module nft_protocol::test_ob_commission {
     // TODO: test trading with commission - check all assertions and that the
     // funds are wrapped in the right way
 
+    use nft_protocol::orderbook::{Self as ob, Orderbook};
     use nft_protocol::test_utils as test_ob;
+    use sui::sui::SUI;
     use sui::test_scenario;
+    use sui::transfer::transfer;
 
     const SELLER: address = @0xA1C06;
     const CREATOR: address = @0xA1C05;
@@ -28,6 +31,39 @@ module nft_protocol::test_ob_commission {
             CREATOR,
             101,
         );
+
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_lists_nft() {
+        let scenario = test_scenario::begin(CREATOR);
+
+        test_ob::create_collection_and_allowlist(&mut scenario);
+        let _ob_id = test_ob::create_ob<test_ob::Foo>(&mut scenario);
+        test_scenario::next_tx(&mut scenario, SELLER);
+        test_ob::create_safe(&mut scenario, SELLER);
+        let nft_id = test_ob::create_and_deposit_nft(&mut scenario, SELLER);
+        test_scenario::next_tx(&mut scenario, SELLER);
+
+        let (owner_cap, seller_safe) =
+            test_ob::owner_cap_and_safe(&scenario, SELLER);
+        let ob: Orderbook<test_ob::Foo, SUI> =
+            test_scenario::take_shared(&scenario);
+        ob::list_nft_with_commission(
+            &mut ob,
+            100,
+            nft_id,
+            &owner_cap,
+            CREATOR,
+            10,
+            &mut seller_safe,
+            test_scenario::ctx(&mut scenario),
+        );
+
+        test_scenario::return_shared(ob);
+        test_scenario::return_shared(seller_safe);
+        transfer(owner_cap, SELLER);
 
         test_scenario::end(scenario);
     }

--- a/tests/orderbook/trade.move
+++ b/tests/orderbook/trade.move
@@ -1,13 +1,14 @@
 #[test_only]
 module nft_protocol::test_ob_trade {
-    use originmate::crit_bit_u64 as crit_bit;
     use nft_protocol::orderbook::{Self as ob, Orderbook};
     use nft_protocol::safe;
     use nft_protocol::test_utils::{Self as test_ob};
+    use originmate::crit_bit_u64 as crit_bit;
     use std::option;
     use sui::object::ID;
     use sui::sui::SUI;
     use sui::test_scenario::{Self, Scenario};
+    use sui::transfer::transfer;
 
     const BUYER1: address = @0xA1C07;
     const BUYER2: address = @0xA1C06;
@@ -301,6 +302,37 @@ module nft_protocol::test_ob_trade {
             SELLER1,
             90,
         );
+
+        test_scenario::end(scenario);
+    }
+
+    #[test]
+    fun it_lists_nft() {
+        let scenario = test_scenario::begin(CREATOR);
+
+        test_ob::create_collection_and_allowlist(&mut scenario);
+        let _ob_id = test_ob::create_ob<test_ob::Foo>(&mut scenario);
+        test_scenario::next_tx(&mut scenario, SELLER1);
+        test_ob::create_safe(&mut scenario, SELLER1);
+        let nft_id = test_ob::create_and_deposit_nft(&mut scenario, SELLER1);
+        test_scenario::next_tx(&mut scenario, SELLER1);
+
+        let (owner_cap, seller_safe) =
+            test_ob::owner_cap_and_safe(&scenario, SELLER1);
+        let ob: Orderbook<test_ob::Foo, SUI> =
+            test_scenario::take_shared(&scenario);
+        ob::list_nft(
+            &mut ob,
+            100,
+            nft_id,
+            &owner_cap,
+            &mut seller_safe,
+            test_scenario::ctx(&mut scenario),
+        );
+
+        test_scenario::return_shared(ob);
+        test_scenario::return_shared(seller_safe);
+        transfer(owner_cap, SELLER1);
 
         test_scenario::end(scenario);
     }


### PR DESCRIPTION

### Added

- `orderbook::list_nft` and `orderbook::list_nft_with_commission` endpoints.
  These allow the client to skip the creation of transfer caps and instead
  provide `OwnerCap` to `Safe` directly to the orderbook contract.
