### PR TITLE
Feature: Compose `Nft.url`

### DIFF
--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -1,12 +1,12 @@
 module nft_protocol::footbytes {
     use std::string::{Self, String};
 
-    use sui::url;
     use sui::balance;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::nft;
+    use nft_protocol::url;
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
@@ -44,7 +44,7 @@ module nft_protocol::footbytes {
             string::utf8(b"A NFT collection of football player collectibles"),
         );
 
-        display::add_collection_url_domain(
+        url::add_collection_url_domain(
             &Witness {},
             &mut collection,
             sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
@@ -106,7 +106,7 @@ module nft_protocol::footbytes {
         supply: u64,
         ctx: &mut TxContext,
     ) {
-        let url = url::new_unsafe_from_bytes(url);
+        let url = sui::url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
 
@@ -114,7 +114,7 @@ module nft_protocol::footbytes {
             &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(&Witness {}, &mut nft, url);
+        url::add_url_domain(&Witness {}, &mut nft, url);
 
         let metadata = metadata::new_regulated(nft, supply, ctx);
         metadata_bag::add_metadata_to_collection(mint_cap, collection, metadata);

--- a/examples/simple.move
+++ b/examples/simple.move
@@ -2,13 +2,13 @@
 module nft_protocol::example_simple {
     use std::string::{Self, String};
 
-    use sui::url;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::collection;
     use nft_protocol::display;
+    use nft_protocol::url;
     use nft_protocol::mint_cap::MintCap;
 
     /// One time witness is only instantiated in the init method
@@ -53,7 +53,7 @@ module nft_protocol::example_simple {
         _mint_cap: &MintCap<EXAMPLE_SIMPLE>,
         ctx: &mut TxContext,
     ) {
-        let url = url::new_unsafe_from_bytes(url);
+        let url = sui::url::new_unsafe_from_bytes(url);
 
         let nft: Nft<EXAMPLE_SIMPLE> = nft::new(
             &Witness {},
@@ -67,7 +67,7 @@ module nft_protocol::example_simple {
             &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(&Witness {}, &mut nft, url);
+        url::add_url_domain(&Witness {}, &mut nft, url);
 
         transfer::transfer(nft, tx_context::sender(ctx));
     }

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -1,4 +1,5 @@
 module nft_protocol::suimarines {
+    use std::ascii;
     use std::string::{Self, String};
     use std::vector;
 
@@ -6,14 +7,15 @@ module nft_protocol::suimarines {
     use sui::balance;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
-    use sui::url;
 
     use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::url;
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
     use nft_protocol::witness;
     use nft_protocol::creators;
+    use nft_protocol::attributes;
     use nft_protocol::mint_cap::{Self, MintCap};
     use nft_protocol::transfer_allowlist;
     use nft_protocol::warehouse::{Self, Warehouse};
@@ -55,7 +57,7 @@ module nft_protocol::suimarines {
             string::utf8(b"A unique NFT collection of Suimarines on Sui"),
         );
 
-        display::add_collection_url_domain(
+        url::add_collection_url_domain(
             &Witness {},
             &mut collection,
             sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
@@ -113,8 +115,8 @@ module nft_protocol::suimarines {
         name: String,
         description: String,
         url: vector<u8>,
-        attribute_keys: vector<String>,
-        attribute_values: vector<String>,
+        attribute_keys: vector<ascii::String>,
+        attribute_values: vector<ascii::String>,
         mint_cap: &MintCap<SUIMARINES>,
         warehouse: &mut Warehouse<SUIMARINES>,
         ctx: &mut TxContext,
@@ -136,8 +138,8 @@ module nft_protocol::suimarines {
         name: vector<String>,
         description: vector<String>,
         url: vector<vector<u8>>,
-        attribute_keys: vector<vector<String>>,
-        attribute_values: vector<vector<String>>,
+        attribute_keys: vector<vector<ascii::String>>,
+        attribute_values: vector<vector<ascii::String>>,
         mint_cap: &MintCap<SUIMARINES>,
         warehouse: &mut Warehouse<SUIMARINES>,
         ctx: &mut TxContext,
@@ -170,12 +172,12 @@ module nft_protocol::suimarines {
         name: String,
         description: String,
         url: vector<u8>,
-        attribute_keys: vector<String>,
-        attribute_values: vector<String>,
+        attribute_keys: vector<ascii::String>,
+        attribute_values: vector<ascii::String>,
         mint_cap: &MintCap<SUIMARINES>,
         ctx: &mut TxContext,
     ): Nft<SUIMARINES> {
-        let url = url::new_unsafe_from_bytes(url);
+        let url = sui::url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
 
@@ -183,9 +185,9 @@ module nft_protocol::suimarines {
             &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(&Witness {}, &mut nft, url);
+        url::add_url_domain(&Witness {}, &mut nft, url);
 
-        display::add_attributes_domain_from_vec(
+        attributes::add_domain_from_vec(
             &Witness {}, &mut nft, attribute_keys, attribute_values,
         );
 

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -1,17 +1,19 @@
 module nft_protocol::suitraders {
+    use std::ascii;
     use std::string::{Self, String};
 
-    use sui::url;
     use sui::balance;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
     use nft_protocol::nft;
+    use nft_protocol::url;
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
     use nft_protocol::witness;
     use nft_protocol::creators;
+    use nft_protocol::attributes;
     use nft_protocol::warehouse::{Self, Warehouse};
     use nft_protocol::royalties::{Self, TradePayment};
     use nft_protocol::collection::{Self, Collection};
@@ -45,7 +47,7 @@ module nft_protocol::suitraders {
             string::utf8(b"A unique NFT collection of Suitraders on Sui"),
         );
 
-        display::add_collection_url_domain(
+        url::add_collection_url_domain(
             &Witness {},
             &mut collection,
             sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
@@ -125,13 +127,13 @@ module nft_protocol::suitraders {
         name: String,
         description: String,
         url: vector<u8>,
-        attribute_keys: vector<String>,
-        attribute_values: vector<String>,
+        attribute_keys: vector<ascii::String>,
+        attribute_values: vector<ascii::String>,
         mint_cap: &MintCap<SUITRADERS>,
         warehouse: &mut Warehouse<SUITRADERS>,
         ctx: &mut TxContext,
     ) {
-        let url = url::new_unsafe_from_bytes(url);
+        let url = sui::url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
 
@@ -139,9 +141,9 @@ module nft_protocol::suitraders {
             &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(&Witness {}, &mut nft, url);
+        url::add_url_domain(&Witness {}, &mut nft, url);
 
-        display::add_attributes_domain_from_vec(
+        attributes::add_domain_from_vec(
             &Witness {}, &mut nft, attribute_keys, attribute_values,
         );
 

--- a/examples/tribal_realms.move
+++ b/examples/tribal_realms.move
@@ -1,10 +1,10 @@
 module nft_protocol::tribal_realms {
     use std::string::{Self, String};
 
-    use sui::url;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
+    use nft_protocol::url;
     use nft_protocol::nft;
     use nft_protocol::display;
     use nft_protocol::mint_cap::{MintCap};
@@ -85,12 +85,12 @@ module nft_protocol::tribal_realms {
         warehouse: &mut Warehouse<TRIBAL_REALMS>,
         ctx: &mut TxContext,
     ) {
-        let url = url::new_unsafe_from_bytes(url);
+        let url = sui::url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
 
         display::add_display_domain(&Witness {}, &mut nft, name, description);
-        display::add_url_domain(&Witness {}, &mut nft, url);
+        url::add_url_domain(&Witness {}, &mut nft, url);
 
         c_nft::add_type_domain<TRIBAL_REALMS, Witness, T>(
             &Witness {}, &mut nft,

--- a/sources/standards/attributes.move
+++ b/sources/standards/attributes.move
@@ -1,0 +1,239 @@
+/// Module of the `AttributesDomain`
+///
+/// Used to register string attributes on NFTs.
+///
+/// Interoperability functions are delegated to the `display_ext` module.
+module nft_protocol::attributes {
+    use std::vector;
+    use std::ascii::{Self, String};
+
+    use sui::vec_map::{Self, VecMap};
+
+    use nft_protocol::utils;
+    use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::witness::{Self, Witness as DelegatedWitness};
+
+    /// `AttributesDomain` was not defined
+    ///
+    /// Call `attributes::add` to add `AttributesDomain`.
+    const EUNDEFINED_ATTRIBUTES_DOMAIN: u64 = 1;
+
+    /// `AttributesDomain` already defined
+    ///
+    /// Call `attributes::borrow` to borrow domain.
+    const EEXISTING_DOMAIN: u64 = 2;
+
+    /// Domain for storing NFT string attributes
+    ///
+    /// Changes are replicated to `ComposableUrl` domain as URL parameters.
+    struct AttributesDomain has store {
+        /// Map of attributes
+        map: VecMap<String, String>,
+    }
+
+    /// Witness used to authenticate witness protected endpoints
+    struct Witness has drop {}
+
+    /// Creates new `AttributesDomain`
+    ///
+    /// Need to ensure that `UrlDomain` is updated with attributes if they
+    /// exist therefore function cannot be public.
+    fun new(map: VecMap<String, String>): AttributesDomain {
+        AttributesDomain { map }
+    }
+
+    /// Creates empty `AttributesDomain`
+    ///
+    /// Need to ensure that `UrlDomain` is updated with attributes if they
+    /// exist therefore function cannot be public.
+    fun empty(): AttributesDomain {
+        AttributesDomain { map: vec_map::empty() }
+    }
+
+    /// Creates new `AttributesDomain` from vectors of keys and values
+    ///
+    /// Need to ensure that `UrlDomain` is updated with attributes if they
+    /// exist therefore function cannot be public.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if keys and values vectors have different lengths
+    fun from_vec(
+        keys: vector<String>,
+        values: vector<String>,
+    ): AttributesDomain {
+        let map = utils::from_vec_to_map<String, String>(keys, values);
+        new(map)
+    }
+
+    /// Returns value map of attributes
+    public fun attributes(domain: &AttributesDomain): &VecMap<String, String> {
+        &domain.map
+    }
+
+    /// Gets keys of attributes
+    public fun keys(domain: &AttributesDomain): vector<String> {
+        let (keys, _) = vec_map::into_keys_values(domain.map);
+        keys
+    }
+
+    /// Gets values of attributes
+    public fun values(domain: &AttributesDomain): vector<String> {
+        let (_, values) = vec_map::into_keys_values(domain.map);
+        values
+    }
+
+    /// Serializes attributes as URL parameters
+    public fun as_url_parameters(domain: &AttributesDomain): vector<u8> {
+        let parameters = vector::empty<u8>();
+
+        let attributes = attributes(domain);
+        let size = vec_map::size(attributes);
+
+        // Check if we even expect URL parameters
+        if (size > 0) {
+            vector::append(&mut parameters, b"?");
+        };
+
+        let idx = 0;
+        while (idx < size) {
+            let (key, value) = vec_map::get_entry_by_idx(attributes, idx);
+
+            vector::append(&mut parameters, ascii::into_bytes(*key));
+            vector::append(&mut parameters, b"=");
+            vector::append(&mut parameters, ascii::into_bytes(*value));
+
+            idx = idx + 1;
+
+            // Check if its not the last element
+            if (idx != size) {
+                vector::append(&mut parameters, b"&");
+            }
+        };
+
+        parameters
+    }
+
+    // === Interoperability ===
+
+    /// Returns whether `AttributesDomain` is registered on `Nft`
+    public fun has_domain<C>(nft: &Nft<C>): bool {
+        nft::has_domain<C, AttributesDomain>(nft)
+    }
+
+    /// Borrows `UrlDomain` from `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered on the `Nft`
+    public fun borrow_domain<C>(nft: &Nft<C>): &AttributesDomain {
+        assert_attributes(nft);
+        nft::borrow_domain<C, AttributesDomain>(nft)
+    }
+
+    /// Mutably borrows `UrlDomain` from `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered on the `Nft`
+    fun borrow_domain_mut<C>(nft: &mut Nft<C>): &mut AttributesDomain {
+        assert_attributes(nft);
+        nft::borrow_domain_mut(Witness {}, nft)
+    }
+
+    /// Adds `AttributesDomain` to `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` domain already exists
+    public fun add_domain<C, W>(
+        witness: &W,
+        nft: &mut Nft<C>,
+        map: VecMap<String, String>,
+    ) {
+        add_domain_delegated(witness::from_witness(witness), nft, map)
+    }
+
+    /// Adds `AttributesDomain` to `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` domain already exists
+    public fun add_domain_delegated<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        map: VecMap<String, String>,
+    ) {
+        assert!(!has_domain(nft), EEXISTING_DOMAIN);
+        nft::add_domain_delegated(witness, nft, new(map));
+    }
+
+    /// Adds `AttributesDomain` to `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` domain already exists
+    public fun add_empty_domain<C, W>(
+        witness: &W,
+        nft: &mut Nft<C>,
+    ) {
+        add_empty_domain_delegated(witness::from_witness(witness), nft)
+    }
+
+    /// Adds `AttributesDomain` to `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` domain already exists
+    public fun add_empty_domain_delegated<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+    ) {
+        assert!(!has_domain(nft), EEXISTING_DOMAIN);
+        nft::add_domain_delegated(witness, nft, empty());
+    }
+
+    /// Adds `AttributesDomain` to `Nft` from vector of keys and values
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` domain already exists or keys and values
+    /// vectors have different lengths
+    public fun add_domain_from_vec<C, W>(
+        witness: &W,
+        nft: &mut Nft<C>,
+        keys: vector<String>,
+        values: vector<String>,
+    ) {
+        add_domain_from_vec_delegated(
+            witness::from_witness(witness), nft, keys, values,
+        )
+    }
+
+    /// Adds `AttributesDomain` to `Nft` from vector of keys and values
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` domain already exists or keys and values
+    /// vectors have different lengths
+    public fun add_domain_from_vec_delegated<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        keys: vector<String>,
+        values: vector<String>,
+    ) {
+        assert!(!has_domain(nft), EEXISTING_DOMAIN);
+        nft::add_domain_delegated(witness, nft, from_vec(keys, values));
+    }
+
+    // === Assertions ===
+
+    /// Asserts that `AttributesDomain` is registered on `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `AttributesDomain` is not registered
+    public fun assert_attributes<C>(nft: &Nft<C>) {
+        assert!(has_domain(nft), EUNDEFINED_ATTRIBUTES_DOMAIN);
+    }
+}

--- a/sources/standards/composability/svg.move
+++ b/sources/standards/composability/svg.move
@@ -27,7 +27,7 @@ module nft_protocol::composable_svg {
 
     /// `ComposableSvgDomain` did not compose NFT with given ID
     ///
-    /// Call `nft_bag::deregister` with an NFT ID that exists.
+    /// Call `composable_svg::deregister` with an NFT ID that exists.
     const EUNDEFINED_NFT: u64 = 3;
 
     /// Domain for providing composed SVG data
@@ -83,7 +83,11 @@ module nft_protocol::composable_svg {
     /// - `NftBagDomain` doesn't exist
     /// - NFT was of a different collection type
     /// - NFT wasn't composed
-    public entry fun register<C>(parent_nft: &mut Nft<C>, child_nft_id: ID) {
+    public fun register<C>(
+        _witness: DelegatedWitness<C>,
+        parent_nft: &mut Nft<C>,
+        child_nft_id: ID,
+    ) {
         let nft_bag_domain = nft_bag::borrow_domain_mut(parent_nft);
 
         // Assert that child NFT exists and it has `SvgDomain`
@@ -104,7 +108,11 @@ module nft_protocol::composable_svg {
     ///
     /// - `ComposableSvgDomain` doesn't exist
     /// - NFT wasn't composed
-    public entry fun deregister<C>(parent_nft: &mut Nft<C>, child_nft_id: ID) {
+    public fun deregister<C>(
+        _witness: DelegatedWitness<C>,
+        parent_nft: &mut Nft<C>,
+        child_nft_id: ID,
+    ) {
         let domain = borrow_domain_mut(parent_nft);
 
         let (has_entry, idx) = vector::index_of(&domain.nfts, &child_nft_id);

--- a/sources/standards/composability/url.move
+++ b/sources/standards/composability/url.move
@@ -1,0 +1,215 @@
+/// Module of `ComposableUrlDomain`
+///
+/// `ComposableUrlDomain` does not itself compose NFTs but serves as a display
+/// standard provider for NFTs which register `UrlDomain` and
+/// `AttribtuesDomain` and are composed within `NftBagDomain`.
+module nft_protocol::composable_url {
+    use std::ascii;
+    use std::vector;
+
+    use sui::object::ID;
+    use sui::url::Url;
+
+    use nft_protocol::url;
+    use nft_protocol::svg;
+    use nft_protocol::nft_bag;
+    use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::attributes;
+    use nft_protocol::witness::Witness as DelegatedWitness;
+
+    /// `ComposableUrlDomain` was not defined
+    ///
+    /// Call `composable_url::add_domain` or to add `ComposableUrlDomain`.
+    const EUNDEFINED_URL_DOMAIN: u64 = 1;
+
+    /// `ComposableUrlDomain` already defined
+    ///
+    /// Call `composable_url::borrow_domain` to borrow domain.
+    const EEXISTING_URL_DOMAIN: u64 = 2;
+
+    /// `ComposableUrlDomain` did not compose NFT with given ID
+    ///
+    /// Call `composable_url::deregister` with an NFT ID that exists.
+    const EUNDEFINED_NFT: u64 = 3;
+
+    /// Domain for providing composed URL data
+    struct ComposableUrlDomain has store {
+        /// NFTs which are being composed
+        nfts: vector<ID>,
+        /// Composed URL
+        url: Url,
+    }
+
+    /// Witness used to authenticate witness protected endpoints
+    struct Witness has drop {}
+
+    /// Creates new `ComposableUrlDomain` with no predefined NFTs
+    public fun new(): ComposableUrlDomain {
+        ComposableUrlDomain {
+            nfts: vector::empty(),
+            url: sui::url::new_unsafe_from_bytes(b""),
+        }
+    }
+
+    /// Borrows root tag attributes from `ComposableUrlDomain`
+    public fun borrow_url(domain: &ComposableUrlDomain): &Url {
+        &domain.url
+    }
+
+    /// Borrows registered NFTs from `ComposableUrlDomain`
+    public fun borrow_nfts(domain: &ComposableUrlDomain): &vector<ID> {
+        &domain.nfts
+    }
+
+    /// Sets URL of `ComposableUrlDomain`
+    ///
+    /// Also sets static `url` field on `Nft`.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `ComposableUrlDomain` does not exist on `Nft`
+    public fun set_url<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        url: Url,
+    ) {
+        let domain = borrow_domain_mut(nft);
+        domain.url = url;
+
+        url::set_url(witness, nft, url);
+    }
+
+    /// Registers NFT whose SVG data should be composed within the final
+    /// composed SVG
+    ///
+    /// `ComposableUrlDomain` will not be automatically updated so
+    /// `composable_url::regenerate` must be called.
+    ///
+    /// #### Panics
+    ///
+    /// - `ComposableUrlDomain` doesn't exist
+    /// - `NftBagDomain` doesn't exist
+    /// - NFT was of a different collection type
+    /// - NFT wasn't composed
+    public fun register<C>(
+        _witness: DelegatedWitness<C>,
+        parent_nft: &mut Nft<C>,
+        child_nft_id: ID,
+    ) {
+        let nft_bag_domain = nft_bag::borrow_domain_mut(parent_nft);
+
+        // Assert that child NFT exists and it has `SvgDomain`
+        let child_nft = nft_bag::borrow<C>(nft_bag_domain, child_nft_id);
+        svg::assert_svg(child_nft);
+
+        let domain = borrow_domain_mut(parent_nft);
+        vector::push_back(&mut domain.nfts, child_nft_id);
+    }
+
+    /// Deregisters NFT whose SVG data is being composed within
+    /// `ComposableUrlDomain`
+    ///
+    /// `ComposableUrlDomain` will not be automatically updated so
+    /// `composable_url::regenerate` must be called.
+    ///
+    /// #### Panics
+    ///
+    /// - `ComposableUrlDomain` doesn't exist
+    /// - NFT wasn't composed
+    public fun deregister<C>(
+        _witness: DelegatedWitness<C>,
+        parent_nft: &mut Nft<C>,
+        child_nft_id: ID,
+    ) {
+        let domain = borrow_domain_mut(parent_nft);
+
+        let (has_entry, idx) = vector::index_of(&domain.nfts, &child_nft_id);
+        assert!(has_entry, EUNDEFINED_NFT);
+
+        vector::remove(&mut domain.nfts, idx);
+    }
+
+    /// Regenerates composed SVG data
+    ///
+    /// NFTs which were removed from `NftBagDomain` or whose `SvgDomain`
+    /// was unregistered will be skipped.
+    ///
+    /// #### Panics
+    ///
+    /// - `ComposableUrlDomain` is not registered
+    /// - `NftBagDomain` is not registered
+    public fun regenerate<C>(
+        // TODO: Remove delegated witness by removing static fields from `Nft`
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+    ) {
+        if (url::has_url(nft)) {
+            let url = ascii::into_bytes(sui::url::inner_url(url::borrow_url(nft)));
+
+            if (attributes::has_domain(nft)) {
+                let attributes_domain = attributes::borrow_domain(nft);
+                let parameters = attributes::as_url_parameters(attributes_domain);
+
+                vector::append(&mut url, parameters);
+            };
+
+            // Set `Nft.url` to composed URL
+            set_url(witness, nft, sui::url::new_unsafe_from_bytes(url));
+        };
+    }
+
+    // === Interoperability ===
+
+    /// Returns whether `ComposableUrlDomain` is registered on `Nft`
+    public fun has_domain<C>(nft: &Nft<C>): bool {
+        nft::has_domain<C, ComposableUrlDomain>(nft)
+    }
+
+    /// Borrows composed URL data from `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `ComposableUrlDomain` is not registered on the `Nft`
+    public fun borrow_domain<C>(nft: &Nft<C>): &ComposableUrlDomain {
+        assert_composable_url(nft);
+        nft::borrow_domain(nft)
+    }
+
+    /// Mutably borrows SVG data from `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `SvgDomain` is not registered on the `Nft`
+    fun borrow_domain_mut<C>(nft: &mut Nft<C>): &mut ComposableUrlDomain {
+        assert_composable_url(nft);
+        nft::borrow_domain_mut(Witness {}, nft)
+    }
+
+    /// Adds `SvgDomain` to `Nft`
+    ///
+    /// `ComposableUrlDomain` will not be automatically updated so
+    /// `composable_url::register` and `composable_url::regenerate` must be
+    /// called.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `SvgDomain` domain already exists
+    public fun add_domain<C>(
+        _witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+    ) {
+        assert!(!has_domain(nft), EEXISTING_URL_DOMAIN);
+        nft::add_domain(&Witness {}, nft, new());
+    }
+
+    // === Assertions ===
+
+    /// Asserts that `ComposableUrlDomain` is registered on `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `ComposableUrlDomain` is not registered
+    public fun assert_composable_url<C>(nft: &Nft<C>) {
+        assert!(has_domain(nft), EUNDEFINED_URL_DOMAIN);
+    }
+}

--- a/sources/standards/composability/url.move
+++ b/sources/standards/composability/url.move
@@ -1,18 +1,16 @@
 /// Module of `ComposableUrlDomain`
 ///
 /// `ComposableUrlDomain` does not itself compose NFTs but serves as a display
-/// standard provider for NFTs which register `UrlDomain` and
-/// `AttribtuesDomain` and are composed within `NftBagDomain`.
+/// standard provider for and NFT which composes `UrlDomain` with
+/// `AttributesDomain`.
 module nft_protocol::composable_url {
     use std::ascii;
     use std::vector;
 
-    use sui::object::ID;
     use sui::url::Url;
 
     use nft_protocol::url;
-    use nft_protocol::svg;
-    use nft_protocol::nft_bag;
+    use nft_protocol::witness;
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::attributes;
     use nft_protocol::witness::Witness as DelegatedWitness;
@@ -27,15 +25,8 @@ module nft_protocol::composable_url {
     /// Call `composable_url::borrow_domain` to borrow domain.
     const EEXISTING_URL_DOMAIN: u64 = 2;
 
-    /// `ComposableUrlDomain` did not compose NFT with given ID
-    ///
-    /// Call `composable_url::deregister` with an NFT ID that exists.
-    const EUNDEFINED_NFT: u64 = 3;
-
     /// Domain for providing composed URL data
     struct ComposableUrlDomain has store {
-        /// NFTs which are being composed
-        nfts: vector<ID>,
         /// Composed URL
         url: Url,
     }
@@ -46,19 +37,8 @@ module nft_protocol::composable_url {
     /// Creates new `ComposableUrlDomain` with no predefined NFTs
     public fun new(): ComposableUrlDomain {
         ComposableUrlDomain {
-            nfts: vector::empty(),
             url: sui::url::new_unsafe_from_bytes(b""),
         }
-    }
-
-    /// Borrows root tag attributes from `ComposableUrlDomain`
-    public fun borrow_url(domain: &ComposableUrlDomain): &Url {
-        &domain.url
-    }
-
-    /// Borrows registered NFTs from `ComposableUrlDomain`
-    public fun borrow_nfts(domain: &ComposableUrlDomain): &vector<ID> {
-        &domain.nfts
     }
 
     /// Sets URL of `ComposableUrlDomain`
@@ -73,95 +53,39 @@ module nft_protocol::composable_url {
         nft: &mut Nft<C>,
         url: Url,
     ) {
-        let domain = borrow_domain_mut(nft);
-        domain.url = url;
+        let domain_url = borrow_composable_url_mut(nft);
+        *domain_url = url;
 
         url::set_url(witness, nft, url);
     }
 
-    /// Registers NFT whose SVG data should be composed within the final
-    /// composed SVG
-    ///
-    /// `ComposableUrlDomain` will not be automatically updated so
-    /// `composable_url::regenerate` must be called.
+    /// Regenerates composed URL data
     ///
     /// #### Panics
     ///
-    /// - `ComposableUrlDomain` doesn't exist
-    /// - `NftBagDomain` doesn't exist
-    /// - NFT was of a different collection type
-    /// - NFT wasn't composed
-    public fun register<C>(
-        _witness: DelegatedWitness<C>,
-        parent_nft: &mut Nft<C>,
-        child_nft_id: ID,
-    ) {
-        let nft_bag_domain = nft_bag::borrow_domain_mut(parent_nft);
-
-        // Assert that child NFT exists and it has `SvgDomain`
-        let child_nft = nft_bag::borrow<C>(nft_bag_domain, child_nft_id);
-        svg::assert_svg(child_nft);
-
-        let domain = borrow_domain_mut(parent_nft);
-        vector::push_back(&mut domain.nfts, child_nft_id);
-    }
-
-    /// Deregisters NFT whose SVG data is being composed within
-    /// `ComposableUrlDomain`
-    ///
-    /// `ComposableUrlDomain` will not be automatically updated so
-    /// `composable_url::regenerate` must be called.
-    ///
-    /// #### Panics
-    ///
-    /// - `ComposableUrlDomain` doesn't exist
-    /// - NFT wasn't composed
-    public fun deregister<C>(
-        _witness: DelegatedWitness<C>,
-        parent_nft: &mut Nft<C>,
-        child_nft_id: ID,
-    ) {
-        let domain = borrow_domain_mut(parent_nft);
-
-        let (has_entry, idx) = vector::index_of(&domain.nfts, &child_nft_id);
-        assert!(has_entry, EUNDEFINED_NFT);
-
-        vector::remove(&mut domain.nfts, idx);
-    }
-
-    /// Regenerates composed SVG data
-    ///
-    /// NFTs which were removed from `NftBagDomain` or whose `SvgDomain`
-    /// was unregistered will be skipped.
-    ///
-    /// #### Panics
-    ///
-    /// - `ComposableUrlDomain` is not registered
-    /// - `NftBagDomain` is not registered
+    /// Panics if `ComposableUrlDomain` or `UrlDomain` is not registered
     public fun regenerate<C>(
         // TODO: Remove delegated witness by removing static fields from `Nft`
         witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
     ) {
-        if (url::has_url(nft)) {
-            let url = ascii::into_bytes(sui::url::inner_url(url::borrow_url(nft)));
+        let url = ascii::into_bytes(sui::url::inner_url(url::borrow_url(nft)));
 
-            if (attributes::has_domain(nft)) {
-                let attributes_domain = attributes::borrow_domain(nft);
-                let parameters = attributes::as_url_parameters(attributes_domain);
+        if (attributes::has_domain(nft)) {
+            let attributes_domain = attributes::borrow_domain(nft);
+            let parameters = attributes::as_url_parameters(attributes_domain);
 
-                vector::append(&mut url, parameters);
-            };
-
-            // Set `Nft.url` to composed URL
-            set_url(witness, nft, sui::url::new_unsafe_from_bytes(url));
+            vector::append(&mut url, parameters);
         };
+
+        // Set `Nft.url` to composed URL
+        set_url(witness, nft, sui::url::new_unsafe_from_bytes(url));
     }
 
     // === Interoperability ===
 
     /// Returns whether `ComposableUrlDomain` is registered on `Nft`
-    public fun has_domain<C>(nft: &Nft<C>): bool {
+    public fun has_composable_url<C>(nft: &Nft<C>): bool {
         nft::has_domain<C, ComposableUrlDomain>(nft)
     }
 
@@ -170,22 +94,25 @@ module nft_protocol::composable_url {
     /// #### Panics
     ///
     /// Panics if `ComposableUrlDomain` is not registered on the `Nft`
-    public fun borrow_domain<C>(nft: &Nft<C>): &ComposableUrlDomain {
+    public fun borrow_composable_url<C>(nft: &Nft<C>): &Url {
         assert_composable_url(nft);
-        nft::borrow_domain(nft)
+        let domain: &ComposableUrlDomain = nft::borrow_domain(nft);
+        &domain.url
     }
 
-    /// Mutably borrows SVG data from `Nft`
+    /// Mutably borrows URL data from `Nft`
     ///
     /// #### Panics
     ///
-    /// Panics if `SvgDomain` is not registered on the `Nft`
-    fun borrow_domain_mut<C>(nft: &mut Nft<C>): &mut ComposableUrlDomain {
+    /// Panics if `UrlDomain` is not registered on the `Nft`
+    fun borrow_composable_url_mut<C>(nft: &mut Nft<C>): &mut Url {
         assert_composable_url(nft);
-        nft::borrow_domain_mut(Witness {}, nft)
+        let domain: &mut ComposableUrlDomain =
+            nft::borrow_domain_mut(Witness {}, nft);
+        &mut domain.url
     }
 
-    /// Adds `SvgDomain` to `Nft`
+    /// Adds `UrlDomain` to `Nft`
     ///
     /// `ComposableUrlDomain` will not be automatically updated so
     /// `composable_url::register` and `composable_url::regenerate` must be
@@ -193,12 +120,28 @@ module nft_protocol::composable_url {
     ///
     /// #### Panics
     ///
-    /// Panics if `SvgDomain` domain already exists
-    public fun add_domain<C>(
+    /// Panics if `UrlDomain` domain already exists
+    public fun add_composable_url<C, W>(
+        witness: &W,
+        nft: &mut Nft<C>,
+    ) {
+        add_composable_url_delegated(witness::from_witness(witness), nft);
+    }
+
+    /// Adds `UrlDomain` to `Nft`
+    ///
+    /// `ComposableUrlDomain` will not be automatically updated so
+    /// `composable_url::register` and `composable_url::regenerate` must be
+    /// called.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` domain already exists
+    public fun add_composable_url_delegated<C>(
         _witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
     ) {
-        assert!(!has_domain(nft), EEXISTING_URL_DOMAIN);
+        assert!(!has_composable_url(nft), EEXISTING_URL_DOMAIN);
         nft::add_domain(&Witness {}, nft, new());
     }
 
@@ -210,6 +153,6 @@ module nft_protocol::composable_url {
     ///
     /// Panics if `ComposableUrlDomain` is not registered
     public fun assert_composable_url<C>(nft: &Nft<C>) {
-        assert!(has_domain(nft), EUNDEFINED_URL_DOMAIN);
+        assert!(has_composable_url(nft), EUNDEFINED_URL_DOMAIN);
     }
 }

--- a/sources/standards/display.move
+++ b/sources/standards/display.move
@@ -9,12 +9,9 @@ module nft_protocol::display {
     use std::string::String;
     use std::option::{Self, Option};
 
-    use sui::url::Url;
     use sui::object::ID;
-    use sui::vec_map::{Self, VecMap};
 
     use nft_protocol::witness;
-    use nft_protocol::utils;
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::witness::Witness as DelegatedWitness;
     use nft_protocol::collection::{Self, Collection};
@@ -123,70 +120,6 @@ module nft_protocol::display {
         nft::remove_domain<C, Witness, DisplayDomain>(Witness {}, nft)
     }
 
-    // === UrlDomain ===
-
-    struct UrlDomain has store {
-        url: Url,
-    }
-
-    /// Gets URL of `UrlDomain`
-    public fun url(domain: &UrlDomain): &Url {
-        &domain.url
-    }
-
-    /// Creates new `UrlDomain` with a URL
-    public fun new_url_domain(url: Url): UrlDomain {
-        UrlDomain { url }
-    }
-
-    /// Sets name of `UrlDomain`
-    ///
-    /// Requires that `AttributionDomain` is defined and sender is a creator
-    public fun set_url<C>(
-        _witness: DelegatedWitness<C>,
-        collection: &mut Collection<C>,
-        url: Url,
-    ) {
-        let domain: &mut UrlDomain =
-            collection::borrow_domain_mut(Witness {}, collection);
-
-        domain.url = url;
-    }
-
-    // ====== Interoperability ===
-
-    public fun display_url<C>(nft: &Nft<C>): Option<Url> {
-        if (!nft::has_domain<C, UrlDomain>(nft)) {
-            return option::none()
-        };
-
-        option::some(*url(nft::borrow_domain<C, UrlDomain>(nft)))
-    }
-
-    public fun display_collection_url<C>(nft: &Collection<C>): Option<Url> {
-        if (!collection::has_domain<C, UrlDomain>(nft)) {
-            return option::none()
-        };
-
-        option::some(*url(collection::borrow_domain<C, UrlDomain>(nft)))
-    }
-
-    public fun add_url_domain<C, W>(
-        witness: &W,
-        nft: &mut Nft<C>,
-        url: Url,
-    ) {
-        nft::add_domain(witness, nft, new_url_domain(url));
-    }
-
-    public fun add_collection_url_domain<C, W>(
-        witness: &W,
-        nft: &mut Collection<C>,
-        url: Url,
-    ) {
-        collection::add_domain(witness, nft, new_url_domain(url));
-    }
-
     // === SymbolDomain ===
 
     struct SymbolDomain has store {
@@ -253,77 +186,7 @@ module nft_protocol::display {
         collection::add_domain(witness, nft, new_symbol_domain(symbol));
     }
 
-    // === AttributesDomain ===
-
-    struct AttributesDomain has store {
-        map: VecMap<String, String>,
-    }
-
-    /// Gets Keys of `Attributes`
-    public fun attributes(domain: &AttributesDomain): &VecMap<String, String> {
-        &domain.map
-    }
-
-    /// Gets Keys of `Attributes`
-    public fun keys(domain: &AttributesDomain): vector<String> {
-        let (keys, _) = vec_map::into_keys_values(domain.map);
-        keys
-    }
-
-    /// Gets Values of `Attributes`
-    public fun values(domain: &AttributesDomain): vector<String> {
-        let (_, values) = vec_map::into_keys_values(domain.map);
-        values
-    }
-
-    /// Creates new `Attributes` with a keys and values
-    public fun new_attributes_domain(
-        map: VecMap<String, String>,
-    ): AttributesDomain {
-        AttributesDomain { map }
-    }
-
-    public fun new_attributes_domain_from_vec(
-        keys: vector<String>,
-        values: vector<String>,
-    ): AttributesDomain {
-        let map = utils::from_vec_to_map<String, String>(keys, values);
-        new_attributes_domain(map)
-    }
-
-    // ====== Interoperability ===
-
-    public fun display_attribute<C>(nft: &Nft<C>): &AttributesDomain {
-        nft::borrow_domain<C, AttributesDomain>(nft)
-    }
-
-    public fun display_attribute_mut<C>(
-        _witness: DelegatedWitness<C>,
-        nft: &mut Nft<C>,
-    ): &mut AttributesDomain {
-        nft::borrow_domain_mut(Witness {}, nft)
-    }
-
-    public fun add_attributes_domain<C, W>(
-        witness: &W,
-        nft: &mut Nft<C>,
-        map: VecMap<String, String>,
-    ) {
-        nft::add_domain(
-            witness, nft, new_attributes_domain(map),
-        );
-    }
-
-    public fun add_attributes_domain_from_vec<C, W>(
-        witness: &W,
-        nft: &mut Nft<C>,
-        keys: vector<String>,
-        values: vector<String>,
-    ) {
-        nft::add_domain(
-            witness, nft, new_attributes_domain_from_vec(keys, values),
-        );
-    }
+    // === CollectionIdDomain ===
 
     struct CollectionIdDomain has store {
         collection_id: ID,

--- a/sources/standards/url.move
+++ b/sources/standards/url.move
@@ -1,0 +1,211 @@
+/// Module of the `UrlDomain`
+///
+/// Used to associate a URL with `Collection` or `Nft`.add
+///
+/// Interoperability functions are delegated to the `display_ext` module.
+module nft_protocol::url {
+    use sui::url::Url;
+
+    use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::witness::{Self, Witness as DelegatedWitness};
+    use nft_protocol::collection::{Self, Collection};
+
+    /// `UrlDomain` was not defined
+    ///
+    /// Call `url::add` or `url::add_collection` to add `UrlDomain`.
+    const EUNDEFINED_URL_DOMAIN: u64 = 1;
+
+    /// `UrlDomain` already defined
+    ///
+    /// Call `url::borrow` or url::borrow_collection` to borrow domain.
+    const EEXISTING_DOMAIN: u64 = 2;
+
+    /// Domain for storing an associated URL
+    ///
+    /// Changes are replicated to `ComposableUrl` domain as URL base for NFTs.
+    struct UrlDomain has store {
+        url: Url,
+    }
+
+    /// Witness used to authenticate witness protected endpoints
+    struct Witness has drop {}
+
+    /// Creates new `UrlDomain` with a URL
+    public fun new(url: Url): UrlDomain {
+        UrlDomain { url }
+    }
+
+    /// Sets URL of `UrlDomain`
+    ///
+    /// Need to ensure that `UrlDomain` is updated with attributes if they
+    /// exist therefore function cannot be public.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` does not exist on `Nft`
+    public fun set_url<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        url: Url,
+    ) {
+        let domain_url = borrow_url_mut(nft);
+        *domain_url = url;
+
+        nft::set_url(witness, nft, url);
+    }
+
+    /// Sets URL of `UrlDomain`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` does not exist on `Collection`
+    public fun set_collection_url<C>(
+        _witness: DelegatedWitness<C>,
+        collection: &mut Collection<C>,
+        url: Url,
+    ) {
+        let domain_url = borrow_collection_url_mut(collection);
+        *domain_url = url;
+    }
+
+    // === Interoperability ===
+
+    /// Returns whether `UrlDomain` is registered on `Nft`
+    public fun has_url<C>(nft: &Nft<C>): bool {
+        nft::has_domain<C, UrlDomain>(nft)
+    }
+
+    /// Returns whether `UrlDomain` is registered on `Collection`
+    public fun has_collection_url<C>(collection: &Collection<C>): bool {
+        collection::has_domain<C, UrlDomain>(collection)
+    }
+
+    /// Borrows `UrlDomain` from `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered on the `Nft`
+    public fun borrow_url<C>(nft: &Nft<C>): &Url {
+        assert_url(nft);
+        let domain: &UrlDomain = nft::borrow_domain(nft);
+        &domain.url
+    }
+
+    /// Mutably borrows `UrlDomain` from `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered on the `Nft`
+    fun borrow_url_mut<C>(nft: &mut Nft<C>): &mut Url {
+        assert_url(nft);
+        let domain: &mut UrlDomain = nft::borrow_domain_mut(Witness {}, nft);
+        &mut domain.url
+    }
+
+    /// Borrows `UrlDomain` from `Collection`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered on the `Collection`
+    public fun borrow_collection_url<C>(collection: &Collection<C>): &Url {
+        assert_collection_url(collection);
+        let domain: &UrlDomain = collection::borrow_domain(collection);
+        &domain.url
+    }
+
+    /// Mutably borrows `UrlDomain` from `Collection`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered on the `Collection`
+    fun borrow_collection_url_mut<C>(
+        collection: &mut Collection<C>,
+    ): &mut Url {
+        assert_collection_url(collection);
+        let domain: &mut UrlDomain =
+            collection::borrow_domain_mut(Witness {}, collection);
+        &mut domain.url
+    }
+
+    /// Adds `UrlDomain` to `Nft`
+    ///
+    /// Need to ensure that `UrlDomain` is updated with attributes if they
+    /// exist therefore function cannot be public.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` domain already exists
+    public fun add_url_domain<C, W>(
+        witness: &W,
+        nft: &mut Nft<C>,
+        url: Url,
+    ) {
+        add_url_domain_delegated(witness::from_witness(witness), nft, url)
+    }
+
+    /// Adds `UrlDomain` to `Nft`
+    ///
+    /// Need to ensure that `UrlDomain` is updated with attributes if they
+    /// exist therefore function cannot be public.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` domain already exists
+    public fun add_url_domain_delegated<C>(
+        witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+        url: Url,
+    ) {
+        assert!(!has_url(nft), EEXISTING_DOMAIN);
+        nft::add_domain_delegated(witness, nft, new(url));
+    }
+
+    /// Adds `UrlDomain` to `Collection`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` domain already exists
+    public fun add_collection_url_domain<C, W>(
+        witness: &W,
+        collection: &mut Collection<C>,
+        url: Url,
+    ) {
+        add_collection_url_domain_delegated(
+            witness::from_witness(witness), collection, url,
+        )
+    }
+
+    /// Adds `UrlDomain` to `Collection`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` domain already exists
+    public fun add_collection_url_domain_delegated<C>(
+        witness: DelegatedWitness<C>,
+        collection: &mut Collection<C>,
+        url: Url,
+    ) {
+        assert!(!has_collection_url(collection), EEXISTING_DOMAIN);
+        collection::add_domain_delegated(witness, collection, new(url));
+    }
+
+    // === Assertions ===
+
+    /// Asserts that `UrlDomain` is registered on `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered
+    public fun assert_url<C>(nft: &Nft<C>) {
+        assert!(has_url(nft), EUNDEFINED_URL_DOMAIN);
+    }
+
+    /// Asserts that `UrlDomain` is registered on `Nft`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `UrlDomain` is not registered
+    public fun assert_collection_url<C>(collection: &Collection<C>) {
+        assert!(has_collection_url(collection), EUNDEFINED_URL_DOMAIN);
+    }
+}

--- a/sources/utils/utils.move
+++ b/sources/utils/utils.move
@@ -9,6 +9,9 @@ module nft_protocol::utils {
 
     use nft_protocol::err;
 
+    /// Mismatched length of key and value vectors used in `from_vec_to_map`
+    const EMISMATCHED_KEY_VALUE_LENGTHS: u64 = 1;
+
     /// Used to mark type fields in dynamic fields
     struct Marker<phantom T> has copy, drop, store {}
 
@@ -70,6 +73,11 @@ module nft_protocol::utils {
         keys: vector<K>,
         values: vector<V>,
     ): VecMap<K, V> {
+        assert!(
+            vector::length(&keys) == vector::length(&values),
+            EMISMATCHED_KEY_VALUE_LENGTHS,
+        );
+
         let i = 0;
         let n = vector::length(&keys);
         let map = vec_map::empty<K, V>();

--- a/tests/domains/display.move
+++ b/tests/domains/display.move
@@ -1,17 +1,19 @@
 #[test_only]
 module nft_protocol::test_display {
+    use std::ascii;
     use std::string;
 
     use sui::transfer;
-    use sui::url;
     use sui::vec_map;
     use sui::test_scenario::{Self, ctx};
 
     use nft_protocol::nft;
+    use nft_protocol::url;
     use nft_protocol::collection;
-    use nft_protocol::display::{
-        Self, DisplayDomain, UrlDomain, SymbolDomain, AttributesDomain
-    };
+    use nft_protocol::attributes;
+    use nft_protocol::display::{Self, DisplayDomain, SymbolDomain};
+    use nft_protocol::url::UrlDomain;
+    use nft_protocol::attributes::AttributesDomain;
 
     struct Foo has drop {}
     struct Witness has drop {}
@@ -68,10 +70,10 @@ module nft_protocol::test_display {
 
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
-        display::add_url_domain(
+        url::add_url_domain(
             &Witness {},
             &mut nft,
-            url::new_unsafe_from_bytes(b"https://originbyte.io/"),
+            sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
 
         // If domain does not exist this function call will fail
@@ -88,10 +90,10 @@ module nft_protocol::test_display {
         let (mint_cap, collection) =
             collection::create(&Foo {}, ctx(&mut scenario));
 
-        display::add_collection_url_domain(
+        url::add_collection_url_domain(
             &Witness {},
             &mut collection,
-            url::new_unsafe_from_bytes(b"https://originbyte.io/"),
+            sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
 
         // If domain does not exist this function call will fail
@@ -152,11 +154,11 @@ module nft_protocol::test_display {
 
         let attributes = vec_map::empty();
         vec_map::insert(
-            &mut attributes, string::utf8(b"color"),
-            string::utf8(b"yellow"),
+            &mut attributes, ascii::string(b"color"),
+            ascii::string(b"yellow"),
         );
 
-        display::add_attributes_domain(
+        attributes::add_domain(
             &Witness {},
             &mut nft,
             attributes,


### PR DESCRIPTION
Alternative to https://github.com/Origin-Byte/nft-protocol/pull/243.

Composes `UrlDomain` and `AttributesDomain` into `Nft.url` for best display compatibility.