### PR TITLE
Orderbook endpoints which minimise txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Added
 
+- Helper endpoints in orderbook which allow marketplaces to perform actions in a single tx.
+  The marketplaces can now
+  - `deposit_and_list_nft` (and with commission)
+  - `create_safe_and_deposit_and_list_nft` (and with commission)
+  - `create_safe_and_buy_nft`
+  - `create_safe_and_buy_generic_nft`
 - Added static `name` and `url` fields to `Nft` for better integration with explorer.
 - Added `LimitedFixedPriceMarket`
 - `orderbook::list_nft` and `orderbook::list_nft_with_commission` endpoints.

--- a/sources/trading/orderbook.move
+++ b/sources/trading/orderbook.move
@@ -359,6 +359,51 @@ module nft_protocol::orderbook {
         create_ask(book, requested_tokens, transfer_cap, seller_safe, ctx)
     }
 
+    /// 1. Deposits an NFT to safe
+    /// 2. Calls [`list_nft`]
+    ///
+    /// The type `T` in case of OB collections is `Nft<C>`.
+    /// In case of generic collections `C == T`.
+    ///
+    /// This endpoint is useful mainly for generic collections, because NFTs
+    /// of OB _usually_ live in a safe in the first place.
+    public entry fun deposit_and_list_nft<T: key + store, C, FT>(
+        book: &mut Orderbook<C, FT>,
+        nft: T,
+        requested_tokens: u64,
+        owner_cap: &safe::OwnerCap,
+        seller_safe: &mut Safe,
+        ctx: &mut TxContext,
+    ) {
+        let nft_id = object::id(&nft);
+        safe::deposit_generic_nft_privileged(nft, owner_cap, seller_safe, ctx);
+        list_nft(book, requested_tokens, nft_id, owner_cap, seller_safe, ctx)
+    }
+
+    /// 1. Creates a new safe for the sender
+    /// 2. Calls [`deposit_and_list_nft`]
+    public entry fun create_safe_and_deposit_and_list_nft<T: key + store, C, FT>(
+        book: &mut Orderbook<C, FT>,
+        nft: T,
+        requested_tokens: u64,
+        ctx: &mut TxContext,
+    ) {
+        let seller = tx_context::sender(ctx);
+        let (seller_safe, owner_cap) = safe::new(ctx);
+
+        deposit_and_list_nft(
+            book,
+            nft,
+            requested_tokens,
+            &owner_cap,
+            &mut seller_safe,
+            ctx,
+        );
+
+        transfer(owner_cap, seller);
+        share_object(seller_safe);
+    }
+
     /// Same as [`create_ask`] but protected by
     /// [collection witness](https://docs.originbyte.io/origin-byte/about-our-programs/liquidity-layer/orderbook#witness-protected-actions).
     public fun create_ask_protected<W: drop, C, FT>(
@@ -404,8 +449,8 @@ module nft_protocol::orderbook {
         )
     }
 
-    /// Creates exclusive transfer cap and then calls
-    /// [`create_ask_with_commission`].
+    /// Same as [`list_nft`] but with a
+    /// [commission](https://docs.originbyte.io/origin-byte/about-our-programs/liquidity-layer/orderbook#commission).
     public entry fun list_nft_with_commission<C, FT>(
         book: &mut Orderbook<C, FT>,
         requested_tokens: u64,
@@ -432,6 +477,60 @@ module nft_protocol::orderbook {
             seller_safe,
             ctx,
         )
+    }
+
+    /// Same as [`deposit_and_list_nft_with`] but with a
+    /// [commission](https://docs.originbyte.io/origin-byte/about-our-programs/liquidity-layer/orderbook#commission).
+    public entry fun deposit_and_list_nft_with_commission<T: key + store, C, FT>(
+        book: &mut Orderbook<C, FT>,
+        nft: T,
+        requested_tokens: u64,
+        owner_cap: &safe::OwnerCap,
+        beneficiary: address,
+        commission: u64,
+        seller_safe: &mut Safe,
+        ctx: &mut TxContext,
+    ) {
+        let nft_id = object::id(&nft);
+        safe::deposit_generic_nft_privileged(nft, owner_cap, seller_safe, ctx);
+        list_nft_with_commission(
+            book,
+            requested_tokens,
+            nft_id,
+            owner_cap,
+            beneficiary,
+            commission,
+            seller_safe,
+            ctx,
+        )
+    }
+
+    /// Same as [`create_safe_and_deposit_and_list_nft`] but with a
+    /// [commission](https://docs.originbyte.io/origin-byte/about-our-programs/liquidity-layer/orderbook#commission).
+    public entry fun create_safe_and_deposit_and_list_nft_with_commission<T: key + store, C, FT>(
+        book: &mut Orderbook<C, FT>,
+        nft: T,
+        requested_tokens: u64,
+        beneficiary: address,
+        commission: u64,
+        ctx: &mut TxContext,
+    ) {
+        let seller = tx_context::sender(ctx);
+        let (seller_safe, owner_cap) = safe::new(ctx);
+
+        deposit_and_list_nft_with_commission(
+            book,
+            nft,
+            requested_tokens,
+            &owner_cap,
+            beneficiary,
+            commission,
+            &mut seller_safe,
+            ctx,
+        );
+
+        transfer(owner_cap, seller);
+        share_object(seller_safe);
     }
 
     /// Same as [`create_ask_protected`] but with a
@@ -535,6 +634,30 @@ module nft_protocol::orderbook {
         )
     }
 
+    /// 1. Creates a new [`Safe`] for the sender
+    /// 2. Buys the NFT into this new safe
+    /// 3. Shares the safe and gives the owner cap to sender
+    public entry fun create_safe_and_buy_nft<C, FT>(
+        book: &mut Orderbook<C, FT>,
+        nft_id: ID,
+        price: u64,
+        wallet: &mut Coin<FT>,
+        seller_safe: &mut Safe,
+        allowlist: &Allowlist,
+        ctx: &mut TxContext,
+    ) {
+        let buyer = tx_context::sender(ctx);
+        let (buyer_safe, owner_cap) = safe::new(ctx);
+
+        assert!(!book.protected_actions.buy_nft, err::action_not_public());
+        buy_nft_<C, FT>(
+            book, nft_id, price, wallet, seller_safe, &mut buyer_safe, allowlist, ctx
+        );
+
+        transfer(owner_cap, buyer);
+        share_object(buyer_safe);
+    }
+
     /// Similar to [`buy_nft`] except that this is meant for generic
     /// collections, ie. those which aren't native to our protocol.
     public entry fun buy_generic_nft<C: key + store, FT>(
@@ -550,6 +673,29 @@ module nft_protocol::orderbook {
         buy_generic_nft_<C, FT>(
             book, nft_id, price, wallet, seller_safe, buyer_safe, ctx
         )
+    }
+
+    /// 1. Creates a new [`Safe`] for the sender
+    /// 2. Buys the NFT into this new safe
+    /// 3. Shares the safe and gives the owner cap to sender
+    public entry fun create_safe_and_buy_generic_nft<C: key + store, FT>(
+        book: &mut Orderbook<C, FT>,
+        nft_id: ID,
+        price: u64,
+        wallet: &mut Coin<FT>,
+        seller_safe: &mut Safe,
+        ctx: &mut TxContext,
+    ) {
+        let buyer = tx_context::sender(ctx);
+        let (buyer_safe, owner_cap) = safe::new(ctx);
+
+        assert!(!book.protected_actions.buy_nft, err::action_not_public());
+        buy_generic_nft_<C, FT>(
+            book, nft_id, price, wallet, seller_safe, &mut buyer_safe, ctx
+        );
+
+        transfer(owner_cap, buyer);
+        share_object(buyer_safe);
     }
 
     /// Same as [`buy_nft`] but protected by


### PR DESCRIPTION
A discussion with a marketplace about putting actions into one txs. Here's my response:

> I am wondering how to organize these helper functions.
>
> One option is to have marketplace smart contract into which we can push them. The pro is that you don't rely on OB release cycle which is important going forward. The disadvantage is overhead of setting this up and maintenance.
> The second option is to have this in the OB contract. The advantage is that it's all in one place and other marketplaces or clients can take advantage too. The disadvantage is that at some point we have to release NFT protocol and that's that, no more helper functions.
> A third option is an extension contract maintained by OB where we would publish logic that can viably change but we wouldn't want to update the core contracts.

For simplicity and urgency, I went with option two.