### PR TITLE
Endpoint to cancel ask and discard the transfer cap in a single tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   - `create_safe_and_deposit_and_list_nft` (and with commission)
   - `create_safe_and_buy_nft`
   - `create_safe_and_buy_generic_nft`
+  - `cancel_ask_and_discard_transfer_cap`
 - Added static `name` and `url` fields to `Nft` for better integration with explorer.
 - Added `LimitedFixedPriceMarket`
 - `orderbook::list_nft` and `orderbook::list_nft_with_commission` endpoints.


### PR DESCRIPTION
The marketplaces can now `cancel_ask_and_discard_transfer_cap`