### PR TITLE
Bid ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Helper endpoints in orderbook which allow marketplaces to perform actions in a single tx.
+  The marketplaces can now
+  - `edit_bid`
+  - `create_safe_and_bid`
+  - `create_safe_and_bid_with_commission`
+
 ## [0.23.0] - 2023-02-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   - `edit_bid`
   - `create_safe_and_bid`
   - `create_safe_and_bid_with_commission`
+  - `list_multiple_nfts`
 
 ### Fixed
 
 - Wrong `seller` field in `TradeFilledEvent` when calling the `buy_nft` endpoint
+
+### Changed
+
+- Moved errors from `err` module into `orderbook` module where they are expressed as constants.
 
 ## [0.23.0] - 2023-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   - `create_safe_and_bid`
   - `create_safe_and_bid_with_commission`
 
+### Fixed
+
+- Wrong `seller` field in `TradeFilledEvent` when calling the `buy_nft` endpoint
+
 ## [0.23.0] - 2023-02-16
 
 ### Added

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -8,10 +8,10 @@
 /// use-cases such as `DisplayDomain` which allows wallets and marketplaces to
 /// easily display your NFT.
 module nft_protocol::nft {
-    use std::string::{Self, String};
+    use std::string::String;
     use std::type_name::{Self, TypeName};
 
-    use sui::url::{Self, Url};
+    use sui::url::Url;
     use sui::event;
     use sui::dynamic_field as df;
     use sui::object::{Self, ID, UID};
@@ -503,6 +503,6 @@ module nft_protocol::nft {
     #[test_only]
     /// Create `Nft` without access to `MintCap` or derivatives
     public fun test_mint<C>(owner: address, ctx: &mut TxContext): Nft<C> {
-        new_(string::utf8(b""), url::new_unsafe_from_bytes(b""), owner, ctx)
+        new_(std::string::utf8(b""), sui::url::new_unsafe_from_bytes(b""), owner, ctx)
     }
 }

--- a/sources/trading/orderbook.move
+++ b/sources/trading/orderbook.move
@@ -1428,7 +1428,7 @@ module nft_protocol::orderbook {
             nft: nft_id,
             price,
             seller_safe: object::id(seller_safe),
-            seller: tx_context::sender(ctx),
+            seller,
             trade_intermediate: option::none(),
         });
 

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -85,10 +85,6 @@ module nft_protocol::err {
         return Prefix + 303
     }
 
-    public fun action_not_public(): u64 {
-        return Prefix + 304
-    }
-
     // === Safe ===
 
     public fun safe_cap_mismatch(): u64 {
@@ -149,10 +145,6 @@ module nft_protocol::err {
 
     public fun sender_not_owner(): u64 {
         return Prefix + 700
-    }
-
-    public fun commission_too_high(): u64 {
-        return Prefix + 701
     }
 
     // === Domains ===

--- a/tests/orderbook/cancel_position.move
+++ b/tests/orderbook/cancel_position.move
@@ -18,7 +18,7 @@ module nft_protocol::test_ob_cancel_position {
     const COMMISSION_SUI: u64 = 10;
 
     #[test]
-    #[expected_failure(abort_code = 13370301, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 7, location = nft_protocol::orderbook)]
     fun it_cannot_cancel_non_existing_ask() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -37,7 +37,7 @@ module nft_protocol::test_ob_cancel_position {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370301, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 7, location = nft_protocol::orderbook)]
     fun it_cannot_cancel_someone_elses_ask() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -223,7 +223,7 @@ module nft_protocol::test_ob_cancel_position {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370301, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 7, location = nft_protocol::orderbook)]
     fun it_cannot_cancel_non_existing_bid() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -240,7 +240,7 @@ module nft_protocol::test_ob_cancel_position {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370302, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 5, location = nft_protocol::orderbook)]
     fun it_cannot_cancel_someone_elses_bid() {
         let scenario = test_scenario::begin(CREATOR);
 

--- a/tests/orderbook/commission.move
+++ b/tests/orderbook/commission.move
@@ -17,7 +17,7 @@ module nft_protocol::test_ob_commission {
     const OFFER_SUI: u64 = 100;
 
     #[test]
-    #[expected_failure(abort_code = 13370701, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 2, location = nft_protocol::orderbook)]
     fun it_cannot_create_ask_with_commission_greater_than_requested_tokens() {
         let scenario = test_scenario::begin(CREATOR);
 

--- a/tests/orderbook/safe_to_safe_trade.move
+++ b/tests/orderbook/safe_to_safe_trade.move
@@ -89,7 +89,7 @@ module nft_protocol::test_ob_safe_to_safe_trade {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370410, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 4, location = nft_protocol::orderbook)]
     fun it_fails_if_buyer_safe_eq_seller_safe() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -113,7 +113,7 @@ module nft_protocol::test_ob_safe_to_safe_trade {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370410, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 4, location = nft_protocol::orderbook)]
     fun it_fails_if_buyer_safe_eq_seller_safe_with_generic_collection() {
         let scenario = test_scenario::begin(CREATOR);
 

--- a/tests/orderbook/trade.move
+++ b/tests/orderbook/trade.move
@@ -286,7 +286,7 @@ module nft_protocol::test_ob_trade {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370301, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 7, location = nft_protocol::orderbook)]
     fun it_fails_if_nft_does_not_exist() {
         let scenario = test_scenario::begin(CREATOR);
 

--- a/tests/orderbook/witness_protected_actions.move
+++ b/tests/orderbook/witness_protected_actions.move
@@ -38,7 +38,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_buy_nft() {
         let scenario = test_scenario::begin(CREATOR);
         let nft_id = create_col_wl_ob_nft_safes(&mut scenario);
@@ -122,7 +122,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_create_ask() {
         let scenario = test_scenario::begin(CREATOR);
         let nft_id = create_col_wl_ob_nft_safes(&mut scenario);
@@ -197,7 +197,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_create_bid() {
         let scenario = test_scenario::begin(CREATOR);
         create_col_wl_ob_nft_safes(&mut scenario);
@@ -262,7 +262,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_cancel_ask() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -340,7 +340,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_cancel_bid() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -412,7 +412,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_create_bid_with_commission() {
         let scenario = test_scenario::begin(CREATOR);
 
@@ -430,7 +430,7 @@ module nft_protocol::test_ob_witness_protected_actions {
     }
 
     #[test]
-    #[expected_failure(abort_code = 13370304, location = nft_protocol::orderbook)]
+    #[expected_failure(abort_code = 0, location = nft_protocol::orderbook)]
     fun it_protects_create_ask_with_commission() {
         let scenario = test_scenario::begin(CREATOR);
 


### PR DESCRIPTION

### Added

- Helper endpoints in orderbook which allow marketplaces to perform actions in a single tx.
  The marketplaces can now
  - `edit_bid`
  - `create_safe_and_bid`
  - `create_safe_and_bid_with_commission`

### Fixed

- Wrong `seller` field in `TradeFilledEvent` when calling the `buy_nft` endpoint
