### PR TITLE
Example: Unique symbol domain

### DIFF
--- a/examples/footbytes.move
+++ b/examples/footbytes.move
@@ -10,7 +10,6 @@ module nft_protocol::footbytes {
     use nft_protocol::tags;
     use nft_protocol::royalty;
     use nft_protocol::display;
-    use nft_protocol::witness;
     use nft_protocol::creators;
     use nft_protocol::template;
     use nft_protocol::templates;
@@ -28,10 +27,9 @@ module nft_protocol::footbytes {
 
     fun init(witness: FOOTBYTES, ctx: &mut TxContext) {
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = witness::from_witness(&Witness {});
 
         collection::add_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             creators::from_address<FOOTBYTES, Witness>(
                 &Witness {}, tx_context::sender(ctx),
@@ -40,20 +38,20 @@ module nft_protocol::footbytes {
 
         // Register custom domains
         display::add_collection_display_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             string::utf8(b"Football digital stickers"),
             string::utf8(b"A NFT collection of football player collectibles"),
         );
 
         display::add_collection_url_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
 
         display::add_collection_symbol_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             string::utf8(b"FOOT"),
         );
@@ -61,7 +59,7 @@ module nft_protocol::footbytes {
         let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
         royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             royalty,
         );
@@ -69,13 +67,13 @@ module nft_protocol::footbytes {
         let tags = tags::empty(ctx);
         tags::add_tag(&mut tags, tags::art());
         tags::add_collection_tag_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             tags,
         );
 
-        templates::init_templates<FOOTBYTES>(
-            delegated_witness,
+        templates::init_templates<FOOTBYTES, Witness>(
+            &Witness {},
             &mut collection,
             ctx,
         );
@@ -111,13 +109,12 @@ module nft_protocol::footbytes {
         let url = url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
-        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(
-            delegated_witness, &mut nft, name, description,
+            &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(delegated_witness, &mut nft, url);
+        display::add_url_domain(&Witness {}, &mut nft, url);
 
         let template = template::new_regulated(nft, supply, ctx);
         templates::add_collection_template(mint_cap, collection, template);

--- a/examples/free_for_all.move
+++ b/examples/free_for_all.move
@@ -55,7 +55,7 @@ module nft_protocol::free_for_all_allowlist {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         collection::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             transfer_allowlist_domain::empty(),
         );

--- a/examples/suimarines.move
+++ b/examples/suimarines.move
@@ -31,10 +31,9 @@ module nft_protocol::suimarines {
         let sender = tx_context::sender(ctx);
 
         let (mint_cap, collection) = collection::create(&witness, ctx);
-        let delegated_witness = witness::from_witness(&Witness {});
 
         collection::add_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             creators::from_address<SUIMARINES, Witness>(
                 &Witness {}, sender,
@@ -43,31 +42,31 @@ module nft_protocol::suimarines {
 
         // Register custom domains
         display::add_collection_display_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             string::utf8(b"Suimarines"),
             string::utf8(b"A unique NFT collection of Suimarines on Sui"),
         );
 
         display::add_collection_url_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
 
         display::add_collection_symbol_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             string::utf8(b"SUIM"),
         );
 
         let royalty = royalty::from_address(sender, ctx);
         royalty::add_proportional_royalty(&mut royalty, 100);
-        royalty::add_royalty_domain(delegated_witness, &mut collection, royalty);
+        royalty::add_royalty_domain(&Witness {}, &mut collection, royalty);
 
         let tags = tags::empty(ctx);
         tags::add_tag(&mut tags, tags::art());
-        tags::add_collection_tag_domain(delegated_witness, &mut collection, tags);
+        tags::add_collection_tag_domain(&Witness {}, &mut collection, tags);
 
         let allowlist = transfer_allowlist::create(&Witness {}, ctx);
         transfer_allowlist::insert_collection<SUIMARINES, Witness>(
@@ -77,7 +76,7 @@ module nft_protocol::suimarines {
         );
 
         collection::add_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             transfer_allowlist_domain::empty(),
         );
@@ -116,16 +115,15 @@ module nft_protocol::suimarines {
         let url = url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
-        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(
-            delegated_witness, &mut nft, name, description,
+            &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(delegated_witness, &mut nft, url);
+        display::add_url_domain(&Witness {}, &mut nft, url);
 
         display::add_attributes_domain_from_vec(
-            delegated_witness, &mut nft, attribute_keys, attribute_values,
+            &Witness {}, &mut nft, attribute_keys, attribute_values,
         );
 
         warehouse::deposit_nft(warehouse, nft);

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -30,7 +30,7 @@ module nft_protocol::suitraders {
         let delegated_witness = witness::from_witness(&Witness {});
 
         collection::add_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             creators::from_address<SUITRADERS, Witness>(
                 &Witness {}, tx_context::sender(ctx),
@@ -39,20 +39,20 @@ module nft_protocol::suitraders {
 
         // Register custom domains
         display::add_collection_display_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             string::utf8(b"Suitraders"),
             string::utf8(b"A unique NFT collection of Suitraders on Sui"),
         );
 
         display::add_collection_url_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             sui::url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
 
         display::add_collection_symbol_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             string::utf8(b"SUITR"),
         );
@@ -60,7 +60,7 @@ module nft_protocol::suitraders {
         let royalty = royalty::from_address(tx_context::sender(ctx), ctx);
         royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             royalty,
         );
@@ -68,7 +68,7 @@ module nft_protocol::suitraders {
         let tags = tags::empty(ctx);
         tags::add_tag(&mut tags, tags::art());
         tags::add_collection_tag_domain(
-            delegated_witness,
+            &Witness {},
             &mut collection,
             tags,
         );
@@ -134,16 +134,15 @@ module nft_protocol::suitraders {
         let url = url::new_unsafe_from_bytes(url);
 
         let nft = nft::from_mint_cap(mint_cap, name, url, ctx);
-        let delegated_witness = witness::from_witness(&Witness {});
 
         display::add_display_domain(
-            delegated_witness, &mut nft, name, description,
+            &Witness {}, &mut nft, name, description,
         );
 
-        display::add_url_domain(delegated_witness, &mut nft, url);
+        display::add_url_domain(&Witness {}, &mut nft, url);
 
         display::add_attributes_domain_from_vec(
-            delegated_witness, &mut nft, attribute_keys, attribute_values,
+            &Witness {}, &mut nft, attribute_keys, attribute_values,
         );
 
         warehouse::deposit_nft(warehouse, nft);

--- a/examples/symbol.move
+++ b/examples/symbol.move
@@ -1,0 +1,138 @@
+/// Implements a contract that mints NFTs with a globally unique symbol and
+/// allows associating them with collections
+module nft_protocol::example_symbol {
+    use std::string::{Self, String};
+
+    use sui::sui::SUI;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::vec_set::{Self, VecSet};
+
+    use nft_protocol::orderbook;
+    use nft_protocol::nft::{Self, Nft};
+    use nft_protocol::display;
+    use nft_protocol::collection::{Self, Collection};
+
+    /// One time witness is only instantiated in the init method
+    struct EXAMPLE_SYMBOL has drop {}
+
+    /// Used for authorization of other protected actions.
+    ///
+    /// `Witness` must not be freely exposed to any contract.
+    struct Witness has drop {}
+
+    /// Domain holding a globally unique symbol
+    struct SymbolDomain has store {
+        /// Unique symbol
+        symbol: String,
+    }
+
+    /// Collection domain responsible for storing symbols already registered
+    struct RegistryDomain has store {
+        /// Registered symbols
+        symbols: VecSet<String>,
+    }
+
+    /// Adds registration to `RegistryDomain` and returns unique `SymbolDomain`
+    fun register(
+        registry: &mut RegistryDomain, symbol: String,
+    ): SymbolDomain {
+        vec_set::insert(&mut registry.symbols, symbol);
+        SymbolDomain { symbol }
+    }
+
+    // === Contract functions ===
+
+    /// Called during contract publishing
+    fun init(witness: EXAMPLE_SYMBOL, ctx: &mut TxContext) {
+        let (mint_cap, collection) = collection::create(&witness, ctx);
+
+        collection::add_domain(
+            &Witness {},
+            &mut collection,
+            display::new_display_domain(
+                string::utf8(b"Symbol"),
+                string::utf8(b"Collection of unique symbols on Sui"),
+            )
+        );
+
+        collection::add_domain(
+            &Witness {},
+            &mut collection,
+            RegistryDomain { symbols: vec_set::empty() },
+        );
+
+        orderbook::create<EXAMPLE_SYMBOL, SUI>(ctx);
+
+        transfer::transfer(mint_cap, tx_context::sender(ctx));
+        transfer::share_object(collection);
+    }
+
+    /// Mint `Nft` from `SymbolDomain`
+    public fun mint_nft(
+        domain: SymbolDomain,
+        ctx: &mut TxContext,
+    ): Nft<EXAMPLE_SYMBOL> {
+        let nft: Nft<EXAMPLE_SYMBOL> = nft::new(
+            &Witness {},
+            domain.symbol, // name
+            sui::url::new_unsafe_from_bytes(b""), // url
+            tx_context::sender(ctx), // owner
+            ctx,
+        );
+
+        nft::add_domain(&Witness {}, &mut nft, domain);
+
+        nft
+    }
+
+    /// Extracts `SymbolDomain` by burning `Nft`
+    public fun burn_nft(nft: Nft<EXAMPLE_SYMBOL>): SymbolDomain {
+        display::remove_display_domain(&Witness {}, &mut nft);
+
+        let symbol: SymbolDomain = nft::remove_domain(
+            Witness {}, &mut nft,
+        );
+
+        nft::burn(nft);
+
+        symbol
+    }
+
+    /// Call to mint an NFT with globally unique symbol
+    public entry fun mint_symbol(
+        collection: &mut Collection<EXAMPLE_SYMBOL>,
+        symbol: String,
+        ctx: &mut TxContext,
+    ) {
+        let registry: &mut RegistryDomain =
+            collection::borrow_domain_mut(Witness {}, collection);
+
+        let nft = mint_nft(register(registry, symbol), ctx);
+
+        transfer::transfer(nft, tx_context::sender(ctx));
+    }
+
+    /// Associate `SymbolDomain` to `Collection`
+    public entry fun associate<C>(
+        collection: &mut Collection<C>,
+        nft: Nft<EXAMPLE_SYMBOL>,
+    ) {
+        let domain = burn_nft(nft);
+        collection::add_domain(&Witness {}, collection, domain);
+    }
+
+    /// Disassociate `SymbolDomain` from `Collection`
+    public fun disassociate<C, W>(
+        _witness: &W,
+        collection: &mut Collection<C>,
+        ctx: &mut TxContext,
+    ) {
+        nft_protocol::utils::assert_same_module_as_witness<C, W>();
+
+        let domain: SymbolDomain = collection::remove_domain(Witness {}, collection);
+        let nft = mint_nft(domain, ctx);
+
+        transfer::transfer(nft, tx_context::sender(ctx));
+    }
+}

--- a/sources/collection/collection.move
+++ b/sources/collection/collection.move
@@ -15,6 +15,7 @@ module nft_protocol::collection {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as df;
 
+    use nft_protocol::witness;
     use nft_protocol::mint_cap::{Self, MintCap};
     use nft_protocol::utils::{Self, Marker};
     use nft_protocol::witness::Witness as DelegatedWitness;
@@ -160,17 +161,30 @@ module nft_protocol::collection {
 
     /// Adds domain of type `D` to `Collection`
     ///
+    /// Helper method that can be simply used without knowing what a delegated
+    /// witness is.
+    ///
     /// #### Panics
     ///
     /// Panics if domain `D` already exists.
+    public fun add_domain<C, W, D: store>(
+        witness: &W,
+        collection: &mut Collection<C>,
+        domain: D,
+    ) {
+        add_domain_delegated(
+            witness::from_witness(witness),
+            collection,
+            domain,
+        )
+    }
+
+    /// Adds domain of type `D` to `Collection`
     ///
-    /// #### Usage
+    /// #### Panics
     ///
-    /// ```
-    /// let display_domain = display::new_display_domain(name, description);
-    /// collection::add_domain(&mut nft, mint_cap, display_domain);
-    /// ```
-    public fun add_domain<C, D: store>(
+    /// Panics if domain `D` already exists.
+    public fun add_domain_delegated<C, D: store>(
         _witness: DelegatedWitness<C>,
         collection: &mut Collection<C>,
         domain: D,

--- a/sources/standards/display.move
+++ b/sources/standards/display.move
@@ -12,6 +12,7 @@ module nft_protocol::display {
     use sui::url::Url;
     use sui::vec_map::{Self, VecMap};
 
+    use nft_protocol::witness;
     use nft_protocol::utils;
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::witness::Witness as DelegatedWitness;
@@ -20,7 +21,7 @@ module nft_protocol::display {
     /// Witness used to authenticate witness protected endpoints
     struct Witness has drop {}
 
-    struct DisplayDomain has store {
+    struct DisplayDomain has drop, store {
         name: String,
         description: String,
     }
@@ -85,8 +86,8 @@ module nft_protocol::display {
         collection::borrow_domain(nft)
     }
 
-    public fun add_display_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_display_domain<C, W>(
+        witness: &W,
         nft: &mut Nft<C>,
         name: String,
         description: String,
@@ -96,8 +97,8 @@ module nft_protocol::display {
         );
     }
 
-    public fun add_collection_display_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_collection_display_domain<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         name: String,
         description: String,
@@ -105,6 +106,20 @@ module nft_protocol::display {
         collection::add_domain(
             witness, collection, new_display_domain(name, description)
         );
+    }
+
+    public fun remove_display_domain<C, W>(
+        witness: &W,
+        nft: &mut Nft<C>,
+    ): DisplayDomain {
+        remove_display_domain_delegated(witness::from_witness(witness), nft)
+    }
+
+    public fun remove_display_domain_delegated<C>(
+        _witness: DelegatedWitness<C>,
+        nft: &mut Nft<C>,
+    ): DisplayDomain {
+        nft::remove_domain<C, Witness, DisplayDomain>(Witness {}, nft)
     }
 
     // === UrlDomain ===
@@ -155,16 +170,16 @@ module nft_protocol::display {
         option::some(*url(collection::borrow_domain<C, UrlDomain>(nft)))
     }
 
-    public fun add_url_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_url_domain<C, W>(
+        witness: &W,
         nft: &mut Nft<C>,
         url: Url,
     ) {
         nft::add_domain(witness, nft, new_url_domain(url));
     }
 
-    public fun add_collection_url_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_collection_url_domain<C, W>(
+        witness: &W,
         nft: &mut Collection<C>,
         url: Url,
     ) {
@@ -221,16 +236,16 @@ module nft_protocol::display {
         option::some(*symbol(collection::borrow_domain<C, SymbolDomain>(nft)))
     }
 
-    public fun add_symbol_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_symbol_domain<C, W>(
+        witness: &W,
         nft: &mut Nft<C>,
         symbol: String,
     ) {
         nft::add_domain(witness, nft, new_symbol_domain(symbol));
     }
 
-    public fun add_collection_symbol_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_collection_symbol_domain<C, W>(
+        witness: &W,
         nft: &mut Collection<C>,
         symbol: String,
     ) {
@@ -288,8 +303,8 @@ module nft_protocol::display {
         nft::borrow_domain_mut(Witness {}, nft)
     }
 
-    public fun add_attributes_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_attributes_domain<C, W>(
+        witness: &W,
         nft: &mut Nft<C>,
         map: VecMap<String, String>,
     ) {
@@ -298,16 +313,14 @@ module nft_protocol::display {
         );
     }
 
-    public fun add_attributes_domain_from_vec<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_attributes_domain_from_vec<C, W>(
+        witness: &W,
         nft: &mut Nft<C>,
         keys: vector<String>,
         values: vector<String>,
     ) {
         nft::add_domain(
-            witness,
-            nft,
-            new_attributes_domain_from_vec(keys, values),
+            witness, nft, new_attributes_domain_from_vec(keys, values),
         );
     }
 }

--- a/sources/standards/loose/templates.move
+++ b/sources/standards/loose/templates.move
@@ -7,7 +7,6 @@ module nft_protocol::templates {
     use nft_protocol::mint_cap::{
         MintCap, RegulatedMintCap, UnregulatedMintCap,
     };
-    use nft_protocol::witness::Witness as DelegatedWitness;
 
     use nft_protocol::template::{Self, Template};
     use nft_protocol::loose_mint_cap::LooseMintCap;
@@ -40,8 +39,8 @@ module nft_protocol::templates {
     }
 
     /// Create a `TemplatesDomain` object and register on `Collection`
-    public fun init_templates<C>(
-        witness: DelegatedWitness<C>,
+    public fun init_templates<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         ctx: &mut TxContext,
     ) {
@@ -114,8 +113,8 @@ module nft_protocol::templates {
     }
 
     /// Add `TemplatesDomain` to `Collection`
-    public fun add_registry<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_registry<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         registry: TemplatesDomain<C>,
     ) {

--- a/sources/standards/modify.move
+++ b/sources/standards/modify.move
@@ -52,7 +52,7 @@ module nft_protocol::modify {
         assert_owner(nft, ctx);
         let modify_domain = borrow_modify_domain(collection);
 
-        nft::add_domain(
+        nft::add_domain_delegated(
             witness::delegate(&modify_domain.generator),
             nft,
             domain,
@@ -71,11 +71,7 @@ module nft_protocol::modify {
         collection: &mut Collection<C>,
     ) {
         let domain = new<C, W>(witness);
-        collection::add_domain(
-            witness::from_witness(witness),
-            collection,
-            domain,
-        );
+        collection::add_domain(witness, collection, domain);
     }
 
     /// Borrows `ModifyDomain` from `Collection`

--- a/sources/standards/plugins.move
+++ b/sources/standards/plugins.move
@@ -146,11 +146,7 @@ module nft_protocol::plugins {
         collection: &mut Collection<C>,
     ) {
         let domain = new<C, W>(witness);
-        collection::add_domain(
-            witness::from_witness(witness),
-            collection,
-            domain,
-        );
+        collection::add_domain(witness, collection, domain);
     }
 
     // === Assertions ===

--- a/sources/standards/royalties/royalty.move
+++ b/sources/standards/royalties/royalty.move
@@ -513,8 +513,8 @@ module nft_protocol::royalty {
     }
 
     /// Registers `RoyaltyDomain` on the given `Collection`
-    public fun add_royalty_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_royalty_domain<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         domain: RoyaltyDomain,
     ) {

--- a/sources/standards/supply.move
+++ b/sources/standards/supply.move
@@ -66,8 +66,8 @@ module nft_protocol::supply_domain {
     /// #### Panics
     ///
     /// Panics if collection is already regulated.
-    public fun regulate<C>(
-        witness: DelegatedWitness<C>,
+    public fun regulate<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         max: u64,
         frozen: bool,

--- a/sources/standards/tags.move
+++ b/sources/standards/tags.move
@@ -136,16 +136,16 @@ module nft_protocol::tags {
         collection::borrow_domain_mut(Witness {}, collection)
     }
 
-    public fun add_tag_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_tag_domain<C, W>(
+        witness: &W,
         nft: &mut Nft<C>,
         tags: TagDomain,
     ) {
         nft::add_domain(witness, nft, tags);
     }
 
-    public fun add_collection_tag_domain<C>(
-        witness: DelegatedWitness<C>,
+    public fun add_collection_tag_domain<C, W>(
+        witness: &W,
         collection: &mut Collection<C>,
         tags: TagDomain,
     ) {

--- a/tests/bidding/safe_to_safe_trade.move
+++ b/tests/bidding/safe_to_safe_trade.move
@@ -11,7 +11,6 @@ module nft_protocol::test_bidding_safe_to_safe_trade {
     use sui::tx_context::TxContext;
     use sui::test_scenario::{Self, Scenario, ctx};
 
-    use nft_protocol::witness;
     use nft_protocol::bidding;
     use nft_protocol::royalty::{Self, RoyaltyDomain};
     use nft_protocol::safe::{Self, Safe, OwnerCap};
@@ -126,8 +125,8 @@ module nft_protocol::test_bidding_safe_to_safe_trade {
 
         let royalty = royalty::from_address(CREATOR, ctx(&mut scenario));
         royalty::add_proportional_royalty(&mut royalty, 100);
-        royalty::add_royalty_domain<Foo>(
-            witness::from_witness(&Witness {}), &mut collection, royalty,
+        royalty::add_royalty_domain<Foo, Witness>(
+            &Witness {}, &mut collection, royalty,
         );
 
         // If domain does not exist this function call will fail

--- a/tests/domains/creators.move
+++ b/tests/domains/creators.move
@@ -3,7 +3,6 @@ module nft_protocol::test_creators {
     use sui::transfer;
     use sui::test_scenario::{Self, ctx};
 
-    use nft_protocol::witness;
     use nft_protocol::creators;
     use nft_protocol::collection;
 
@@ -20,7 +19,7 @@ module nft_protocol::test_creators {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         collection::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             creators::from_address<Foo, Witness>(&Witness {}, CREATOR),
         );

--- a/tests/domains/display.move
+++ b/tests/domains/display.move
@@ -8,7 +8,6 @@ module nft_protocol::test_display {
     use sui::test_scenario::{Self, ctx};
 
     use nft_protocol::nft;
-    use nft_protocol::witness;
     use nft_protocol::collection;
     use nft_protocol::display::{
         Self, DisplayDomain, UrlDomain, SymbolDomain, AttributesDomain
@@ -27,7 +26,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_display_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             string::utf8(b"Suimarines-234"),
             string::utf8(b"Collection of Suimarines"),
@@ -48,7 +47,7 @@ module nft_protocol::test_display {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         display::add_collection_display_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             string::utf8(b"Suimarines-234"),
             string::utf8(b"Collection of Suimarines"),
@@ -70,7 +69,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_url_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
@@ -90,7 +89,7 @@ module nft_protocol::test_display {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         display::add_collection_url_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             url::new_unsafe_from_bytes(b"https://originbyte.io/"),
         );
@@ -111,7 +110,7 @@ module nft_protocol::test_display {
         let nft = nft::test_mint<Foo>(CREATOR, ctx);
 
         display::add_symbol_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             string::utf8(b"SUIM-234"),
         );
@@ -131,7 +130,7 @@ module nft_protocol::test_display {
             collection::create(&Foo {}, ctx(&mut scenario));
 
         display::add_collection_symbol_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             string::utf8(b"SUIM"),
         );
@@ -158,7 +157,7 @@ module nft_protocol::test_display {
         );
 
         display::add_attributes_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             attributes,
         );

--- a/tests/domains/royalty.move
+++ b/tests/domains/royalty.move
@@ -3,7 +3,6 @@ module nft_protocol::test_royalty {
     use sui::transfer;
     use sui::test_scenario::{Self, ctx};
 
-    use nft_protocol::witness;
     use nft_protocol::collection;
     use nft_protocol::royalty::{Self, RoyaltyDomain};
 
@@ -23,7 +22,7 @@ module nft_protocol::test_royalty {
         royalty::add_proportional_royalty(&mut royalty, 100);
         royalty::add_constant_royalty(&mut royalty, 100);
         royalty::add_royalty_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             royalty,
         );

--- a/tests/domains/tags.move
+++ b/tests/domains/tags.move
@@ -4,7 +4,6 @@ module nft_protocol::test_tags {
     use sui::test_scenario::{Self, ctx};
 
     use nft_protocol::nft;
-    use nft_protocol::witness;
     use nft_protocol::collection;
     use nft_protocol::tags::{Self, TagDomain};
 
@@ -25,7 +24,7 @@ module nft_protocol::test_tags {
         tags::add_tag(&mut tags, tags::profile_picture());
 
         tags::add_tag_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             tags,
         );
@@ -53,7 +52,7 @@ module nft_protocol::test_tags {
         tags::add_tag(&mut tags, tags::game_asset());
 
         tags::add_collection_tag_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut collection,
             tags,
         );

--- a/tests/nft.move
+++ b/tests/nft.move
@@ -10,7 +10,6 @@ module nft_protocol::fake_witness {
 
 #[test_only]
 module nft_protocol::test_nft {
-    use nft_protocol::witness;
     use nft_protocol::fake_witness::{Self, FakeWitness};
     use nft_protocol::nft::{Self, Nft};
     use nft_protocol::utils;
@@ -50,7 +49,7 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
@@ -70,7 +69,7 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
@@ -92,14 +91,14 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
 
         // This second call will fail
         nft::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             DomainA { id: object::new(ctx) },
         );
@@ -117,7 +116,7 @@ module nft_protocol::test_nft {
         let nft = nft::test_mint<Foo>(OWNER, ctx);
 
         nft::add_domain(
-            witness::from_witness(&Witness {}),
+            &Witness {},
             &mut nft,
             DomainA { id: object::new(ctx) },
         );


### PR DESCRIPTION
Creates new `add_domain_delegated` and `add_domain` endpoints in order to provide a user-friendly endpoint for cases where the user does not need to understand what the delegated witness is.