### PR TITLE
Ergonomics: bidding contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `BidCreated` renamed to `BidCreatedEvent`, generic removed and new fields added.
+  The generic is problematic for the client as it can then query only for event type knowing the fungible token in advance.
+- `BidClosed` event renamed to `BidClosedEvent`, again generic removed and new fields added.
+  Additionally, this event is now used only for cancelling a bid.
+
+### Added
+
+- `BidMatchedEvent` emitted when an NFT is sold.
+
 ## [0.25.0] - 2023-02-24
 
 ### Added
@@ -31,6 +44,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Changed
 
 - Moved errors from `err` module into `orderbook` module where they are expressed as constants.
+
 ## [0.24.0] - 2023-02-22
 
 ### Changed

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -17,6 +17,7 @@ module nft_protocol::bidding {
     use nft_protocol::transfer_allowlist::Allowlist;
     use nft_protocol::trading::{
         AskCommission,
+        bid_commission_amount,
         BidCommission,
         destroy_bid_commission,
         new_ask_commission,
@@ -42,6 +43,7 @@ module nft_protocol::bidding {
         id: ID,
         nft: ID,
         price: u64,
+        commission: u64,
         buyer: address,
         buyer_safe: ID,
         ft: String,
@@ -240,6 +242,12 @@ module nft_protocol::bidding {
         let offer = balance::split(coin::balance_mut(wallet), price);
         let buyer = tx_context::sender(ctx);
 
+        let commission_amount = if(option::is_some(&commission)) {
+            bid_commission_amount(option::borrow(&commission))
+        } else {
+            0
+        };
+
         let bid = Bid<FT> {
             id: object::new(ctx),
             nft,
@@ -256,7 +264,8 @@ module nft_protocol::bidding {
             price,
             buyer,
             buyer_safe: buyers_safe,
-            ft: *type_name::borrow_string(&type_name::get<FT>())
+            ft: *type_name::borrow_string(&type_name::get<FT>()),
+            commission: commission_amount,
         });
 
         bid

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -91,6 +91,10 @@ module nft_protocol::bidding {
         share_object(bid);
     }
 
+    public fun share<FT>(bid: Bid<FT>) {
+        share_object(bid);
+    }
+
     /// Entry function to sell an NFT with an open `bid`.
     ///
     /// It performs the following:

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -38,14 +38,17 @@ module nft_protocol::bidding {
 
     struct BidCreatedEvent<phantom FT> has copy, drop {
         id: ID,
-        for_nft: ID,
+        nft: ID,
         price: u64,
+        buyer: address,
+        buyer_safe: ID,
     }
 
     /// Bid was closed by the user, no sell happened
     struct BidClosedEvent<phantom FT> has copy, drop {
         id: ID,
         nft: ID,
+        buyer: address,
     }
 
     /// NFT was sold
@@ -54,8 +57,8 @@ module nft_protocol::bidding {
         nft: ID,
         price: u64,
         seller: address,
+        buyer: address,
     }
-
 
     /// Payable entry function to create a bid for an NFT.
     ///
@@ -244,8 +247,10 @@ module nft_protocol::bidding {
 
         emit(BidCreatedEvent<FT> {
             id: bid_id,
-            for_nft: nft,
-            price
+            nft: nft,
+            price,
+            buyer,
+            buyer_safe: buyers_safe,
         });
 
         bid
@@ -299,6 +304,7 @@ module nft_protocol::bidding {
             nft: nft_id,
             price,
             seller: tx_context::sender(ctx),
+            buyer: bid.buyer,
         });
     }
 
@@ -341,6 +347,7 @@ module nft_protocol::bidding {
             nft: nft_id,
             price,
             seller: tx_context::sender(ctx),
+            buyer: bid.buyer,
         });
     }
 
@@ -363,6 +370,7 @@ module nft_protocol::bidding {
         emit(BidClosedEvent<FT> {
             id: object::id(bid),
             nft: bid.nft,
+            buyer: sender,
         });
     }
 }

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -36,13 +36,13 @@ module nft_protocol::bidding {
         commission: Option<BidCommission<FT>>,
     }
 
-    struct BidCreated<phantom FT> has copy, drop {
+    struct BidCreatedEvent<phantom FT> has copy, drop {
         id: ID,
         for_nft: ID,
         price: u64,
     }
 
-    struct BidClosed<phantom FT> has copy, drop {
+    struct BidClosedEvent<phantom FT> has copy, drop {
         id: ID,
         /// Either sold or canceled
         sold: bool,
@@ -233,7 +233,7 @@ module nft_protocol::bidding {
         };
         let bid_id = object::id(&bid);
 
-        emit(BidCreated<FT> {
+        emit(BidCreatedEvent<FT> {
             id: bid_id,
             for_nft: nft,
             price
@@ -284,7 +284,7 @@ module nft_protocol::bidding {
 
         transfer_bid_commission(&mut bid.commission, ctx);
 
-        emit(BidClosed<FT> { id: nft_id, sold: true });
+        emit(BidClosedEvent<FT> { id: nft_id, sold: true });
     }
 
     /// Similar to [`sell_nft_`] except that this is meant for generic
@@ -320,7 +320,7 @@ module nft_protocol::bidding {
 
         transfer_bid_commission(&mut bid.commission, ctx);
 
-        emit(BidClosed<FT> { id: nft_id, sold: true });
+        emit(BidClosedEvent<FT> { id: nft_id, sold: true });
     }
 
     fun close_bid_<FT>(bid: &mut Bid<FT>, ctx: &mut TxContext) {

--- a/sources/trading/trading.move
+++ b/sources/trading/trading.move
@@ -146,4 +146,10 @@ module nft_protocol::trading {
             );
         };
     }
+
+    // === Getters ===
+
+    public fun bid_commission_amount<FT>(bid: &BidCommission<FT>): u64 {
+        balance::value(&bid.cut)
+    }
 }


### PR DESCRIPTION

### Changed

- `BidCreated` renamed to `BidCreatedEvent`, generic removed and new fields added.
  The generic is problematic for the client as it can then query only for event type knowing the fungible token in advance.
- `BidClosed` event renamed to `BidClosedEvent`, again generic removed and new fields added.
  Additionally, this event is now used only for cancelling a bid.

### Added

- `BidMatchedEvent` emitted when an NFT is sold.