### PR TITLE
Event type exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Renamed `template::Template` to `metadata::Metadata` and `templates::TemplatesDomain` to `metadata_bag::MetadataBagDomain`
 - `OrderbookCreatedEvent` property `fungible_token_type` renamed to `ft_type` to be consistent with other events.
 - `BidCreatedEvent`, `BidClosedEvent` and `BidMatchedEvent` property `ft` renamed to `ft_type` to be consistent with other events.
+- `MintNftEvent` property `object_type` of type `TypeName` changed to `nft_type` of type `String`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - `BidClosed` event renamed to `BidClosedEvent`, again generic removed and new fields added.
   Additionally, this event is now used only for cancelling a bid.
 - Renamed `template::Template` to `metadata::Metadata` and `templates::TemplatesDomain` to `metadata_bag::MetadataBagDomain`
+- `OrderbookCreatedEvent` property `fungible_token_type` renamed to `ft_type` to be consistent with other events.
+- `BidCreatedEvent`, `BidClosedEvent` and `BidMatchedEvent` property `ft` renamed to `ft_type` to be consistent with other events.
 
 ### Added
 
@@ -22,8 +24,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - `NftSoldEvent` emitted from `limited_fixed_price` launchpad market module.
 - `NftSoldEvent` emitted from `fixed_price` launchpad market module.
 - `ChangeLogicalOwnerEvent` emitted when logical owner of an NFT is changed.
+  It contains old and new logical owner, NFT ID and NFT collection type.
 - `MintNftEvent` now contains `logical_owner` field.
 - Composable standard with domains `nft_bag::NftBagDomain` and `svg::ComposableSvgDomain`
+
+### Fixed
+
+- `OrderbookCreatedEvent` exported collection type instead of FT type.
 
 ## [0.25.0] - 2023-02-24
 

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -8,7 +8,8 @@
 /// use-cases such as `DisplayDomain` which allows wallets and marketplaces to
 /// easily display your NFT.
 module nft_protocol::nft {
-    use std::string::String;
+    use std::ascii;
+    use std::string;
     use std::type_name::{Self, TypeName};
 
     use sui::url::Url;
@@ -55,7 +56,7 @@ module nft_protocol::nft {
         /// `Nft` ID
         id: UID,
         /// `Nft` name
-        name: String,
+        name: string::String,
         /// `Nft` URL
         url: Url,
         /// Represents the logical owner of an NFT
@@ -84,11 +85,13 @@ module nft_protocol::nft {
         old_logical_owner: address,
         /// The address of the new logical owner
         new_logical_owner: address,
+        /// The `TypeName` string of the inner `C` generic of `Nft<C>`.
+        nft_type: ascii::String,
     }
 
     /// Create a new `Nft`
     fun new_<C>(
-        name: String,
+        name: string::String,
         url: Url,
         logical_owner: address,
         ctx: &mut TxContext,
@@ -122,7 +125,7 @@ module nft_protocol::nft {
     /// ```
     public fun new<C, W>(
         _witness: &W,
-        name: String,
+        name: string::String,
         url: Url,
         owner: address,
         ctx: &mut TxContext,
@@ -138,7 +141,7 @@ module nft_protocol::nft {
     /// domains to NFTs not belonging to the transaction sender.
     public fun from_mint_cap<C>(
         _mint_cap: &MintCap<C>,
-        name: String,
+        name: string::String,
         url: Url,
         ctx: &mut TxContext,
     ): Nft<C> {
@@ -162,7 +165,7 @@ module nft_protocol::nft {
     /// Panics if supply is exceeded.
     public fun from_regulated<C>(
         mint_cap: &mut RegulatedMintCap<C>,
-        name: String,
+        name: string::String,
         url: Url,
         ctx: &mut TxContext,
     ): Nft<C> {
@@ -183,7 +186,7 @@ module nft_protocol::nft {
     /// See [new](#new) for usage information.
     public fun from_unregulated<C>(
         _mint_cap: &UnregulatedMintCap<C>,
-        name: String,
+        name: string::String,
         url: Url,
         ctx: &mut TxContext,
     ): Nft<C> {
@@ -223,7 +226,7 @@ module nft_protocol::nft {
     ///
     ///     struct DisplayDomain {
     ///         id: UID,
-    ///         name: String,
+    ///         name: string::String,
     ///     } has key, store
     ///
     ///     public fun domain_mut(nft: &mut Nft<C>): &mut DisplayDomain {
@@ -418,7 +421,7 @@ module nft_protocol::nft {
     // === Static Properties ===
 
     /// Returns `Nft` name
-    public fun name<C>(nft: &Nft<C>): &String {
+    public fun name<C>(nft: &Nft<C>): &string::String {
         &nft.name
     }
 
@@ -434,7 +437,7 @@ module nft_protocol::nft {
     public fun set_name<C>(
         _witness: DelegatedWitness<C>,
         nft: &mut Nft<C>,
-        name: String,
+        name: string::String,
     ) {
         nft.name = name
     }
@@ -504,6 +507,7 @@ module nft_protocol::nft {
             nft_id: object::id(nft),
             old_logical_owner: nft.logical_owner,
             new_logical_owner: recipient,
+            nft_type: type_name::into_string(type_name::get<C>()),
         });
 
         nft.logical_owner = recipient;

--- a/sources/nft/nft.move
+++ b/sources/nft/nft.move
@@ -2,7 +2,7 @@
 ///
 /// OriginByte's NFT protocol brings dynamism, composability and extendability
 /// to NFTs. The current design allows creators to create NFTs with custom
-/// domain-specific fields, with their own bespoke behaviour.
+/// domain-specific fields, with their own bespoke behavior.
 ///
 /// OriginByte provides a set of standard domains which implement common NFT
 /// use-cases such as `DisplayDomain` which allows wallets and marketplaces to
@@ -10,7 +10,7 @@
 module nft_protocol::nft {
     use std::ascii;
     use std::string;
-    use std::type_name::{Self, TypeName};
+    use std::type_name;
 
     use sui::url::Url;
     use sui::event;
@@ -73,7 +73,7 @@ module nft_protocol::nft {
         /// Type name of `Nft<C>` one-time witness `C`
         ///
         /// Intended to allow users to filter by collections of interest.
-        type_name: TypeName,
+        nft_type: ascii::String,
         /// Assigned address which owns the NFT
         logical_owner: address,
     }
@@ -100,7 +100,7 @@ module nft_protocol::nft {
 
         event::emit(MintNftEvent {
             nft_id: object::uid_to_inner(&id),
-            type_name: type_name::get<C>(),
+            nft_type: type_name::into_string(type_name::get<C>()),
             logical_owner,
         });
 

--- a/sources/trading/bidding.move
+++ b/sources/trading/bidding.move
@@ -46,7 +46,7 @@ module nft_protocol::bidding {
         commission: u64,
         buyer: address,
         buyer_safe: ID,
-        ft: String,
+        ft_type: String,
     }
 
     /// Bid was closed by the user, no sell happened
@@ -54,7 +54,7 @@ module nft_protocol::bidding {
         id: ID,
         nft: ID,
         buyer: address,
-        ft: String,
+        ft_type: String,
     }
 
     /// NFT was sold
@@ -64,7 +64,7 @@ module nft_protocol::bidding {
         price: u64,
         seller: address,
         buyer: address,
-        ft: String,
+        ft_type: String,
     }
 
     /// Payable entry function to create a bid for an NFT.
@@ -264,7 +264,7 @@ module nft_protocol::bidding {
             price,
             buyer,
             buyer_safe: buyers_safe,
-            ft: *type_name::borrow_string(&type_name::get<FT>()),
+            ft_type: *type_name::borrow_string(&type_name::get<FT>()),
             commission: commission_amount,
         });
 
@@ -320,7 +320,7 @@ module nft_protocol::bidding {
             price,
             seller: tx_context::sender(ctx),
             buyer: bid.buyer,
-            ft: *type_name::borrow_string(&type_name::get<FT>()),
+            ft_type: *type_name::borrow_string(&type_name::get<FT>()),
         });
     }
 
@@ -364,7 +364,7 @@ module nft_protocol::bidding {
             price,
             seller: tx_context::sender(ctx),
             buyer: bid.buyer,
-            ft: *type_name::borrow_string(&type_name::get<FT>())
+            ft_type: *type_name::borrow_string(&type_name::get<FT>())
         });
     }
 
@@ -388,7 +388,7 @@ module nft_protocol::bidding {
             id: object::id(bid),
             nft: bid.nft,
             buyer: sender,
-            ft: *type_name::borrow_string(&type_name::get<FT>()),
+            ft_type: *type_name::borrow_string(&type_name::get<FT>()),
         });
     }
 }

--- a/sources/trading/orderbook.move
+++ b/sources/trading/orderbook.move
@@ -184,7 +184,7 @@ module nft_protocol::orderbook {
     struct OrderbookCreatedEvent has copy, drop {
         orderbook: ID,
         collection_type: String,
-        fungible_token_type: String,
+        ft_type: String,
     }
 
     struct AskCreatedEvent has copy, drop {
@@ -985,7 +985,7 @@ module nft_protocol::orderbook {
         event::emit(OrderbookCreatedEvent {
             orderbook: object::uid_to_inner(&id),
             collection_type: type_name::into_string(type_name::get<C>()),
-            fungible_token_type: type_name::into_string(type_name::get<C>()),
+            ft_type: type_name::into_string(type_name::get<FT>()),
         });
 
         Orderbook<C, FT> {


### PR DESCRIPTION
- `OrderbookCreatedEvent` property `fungible_token_type` renamed to `ft_type` to be consistent with other events.
- `BidCreatedEvent`, `BidClosedEvent` and `BidMatchedEvent` property `ft` renamed to `ft_type` to be consistent with other events.
- `ChangeLogicalOwnerEvent` emitted when logical owner of an NFT is changed.
  It contains old and new logical owner, NFT ID and NFT collection type.
- `OrderbookCreatedEvent` exported collection type instead of FT type.