### PR TITLE
Feature: Init MintCap via OTW 

### DIFF
--- a/examples/allowlists/free_for_all.move
+++ b/examples/allowlists/free_for_all.move
@@ -3,9 +3,10 @@
 ///
 /// Basically any collection which adds itself to this allowlist is saying:
 /// we're ok with anyone transferring NFTs.
-module nft_protocol::origin_sui {
+module nft_protocol::free_for_all {
     use sui::tx_context::TxContext;
     use sui::package::{Self, Publisher};
+    use sui::object;
 
     use nft_protocol::mint_cap;
     use nft_protocol::witness;
@@ -13,14 +14,14 @@ module nft_protocol::origin_sui {
     use nft_protocol::transfer_allowlist_domain;
     use nft_protocol::transfer_allowlist::{Self, Allowlist};
 
-    struct ORIGIN_SUI has drop {}
+    struct FREE_FOR_ALL has drop {}
 
     struct Witness has drop {}
 
-    fun init(witness: ORIGIN_SUI, ctx: &mut TxContext) {
+    fun init(otw: FREE_FOR_ALL, ctx: &mut TxContext) {
         transfer_allowlist::init_allowlist(&Witness {}, ctx);
 
-        package::claim_and_keep(witness, ctx);
+        package::claim_and_keep(otw, ctx);
     }
 
     public entry fun insert_collection<C>(
@@ -33,7 +34,7 @@ module nft_protocol::origin_sui {
         let delegated_witness = witness::from_publisher(pub);
         transfer_allowlist_domain::add_id(delegated_witness, collection, allowlist);
 
-        let delegated_witness = witness::from_witness<ORIGIN_SUI, Witness>(Witness {});
+        let delegated_witness = witness::from_witness<FREE_FOR_ALL, Witness>(Witness {});
 
         transfer_allowlist::insert_collection(
             allowlist, &Witness {}, delegated_witness,
@@ -49,12 +50,14 @@ module nft_protocol::origin_sui {
 
     #[test_only]
     const USER: address = @0xA1C04;
+    #[test_only]
+    struct SomeRandomType has drop {}
 
     #[test]
     fun test_example_free_for_all() {
         let scenario = test_scenario::begin(USER);
 
-        init(ORIGIN_SUI {}, ctx(&mut scenario));
+        init(FREE_FOR_ALL {}, ctx(&mut scenario));
 
         test_scenario::next_tx(&mut scenario, USER);
 
@@ -65,11 +68,15 @@ module nft_protocol::origin_sui {
 
         let delegated_witness = witness::from_witness(Witness {});
 
-        let collection: Collection<ORIGIN_SUI> =
+        // This could technically be any Collection, we use FREE_FOR_ALL as
+        // the Collection OTW because we cannot claim a mint cap if we don't
+        // have access to an OTW. To avoid having to create another OTW we just
+        // the one instantiated in this contract.
+        let collection: Collection<FREE_FOR_ALL> =
             collection::create(delegated_witness, ctx(&mut scenario));
 
-        let mint_cap = mint_cap::new_unlimited(
-            delegated_witness, &collection, ctx(&mut scenario),
+        let mint_cap = mint_cap::new_unlimited<FREE_FOR_ALL, SomeRandomType>(
+            &FREE_FOR_ALL {}, object::id(&collection), ctx(&mut scenario),
         );
 
         collection::add_domain(

--- a/examples/suitraders.move
+++ b/examples/suitraders.move
@@ -36,29 +36,27 @@ module nft_protocol::suitraders {
         attributes: Attributes,
     }
 
-    fun init(witness: SUITRADERS, ctx: &mut TxContext) {
-        let publisher = sui::package::claim(witness, ctx);
-
-        let delegated_witness = witness::from_witness(Witness {});
+    fun init(otw: SUITRADERS, ctx: &mut TxContext) {
         let sender = tx_context::sender(ctx);
 
+        // Get the Delegated Witness
+        let dw = witness::from_witness(Witness {});
+
+        // Init Collection
         let collection: Collection<SUITRADERS> =
-            collection::create(delegated_witness, ctx);
+            collection::create(dw, ctx);
 
         // Creates an unregulated mint cap
-        let mint_cap = mint_cap::new_from_publisher<Suitrader, SUITRADERS>(
-            &publisher, &collection, option::none(), ctx,
+        let mint_cap = mint_cap::new<SUITRADERS, Suitrader>(
+            &otw, object::id(&collection), option::none(), ctx,
         );
 
-        collection::add_domain(
-            delegated_witness,
-            &mut collection,
-            creators::new(vec_set::singleton(sender)),
-        );
+        // Init Publisher
+        let publisher = sui::package::claim(otw, ctx);
 
-        // Register custom domains
+        // Add name and description to Collection
         collection::add_domain(
-            delegated_witness,
+            dw,
             &mut collection,
             display_info::new(
                 string::utf8(b"Suimarines"),
@@ -66,14 +64,26 @@ module nft_protocol::suitraders {
             ),
         );
 
-        royalty_strategy_bps::create_domain_and_add_strategy(
-            delegated_witness, &mut collection, 100, ctx,
+        // Creators domain
+        collection::add_domain(
+            dw,
+            &mut collection,
+            creators::new(vec_set::singleton(sender)),
         );
 
+        // Royalties
+        royalty_strategy_bps::create_domain_and_add_strategy(
+            dw, &mut collection, 100, ctx,
+        );
+
+        // Tags
         let tags = tags::empty(ctx);
         tags::add_tag(&mut tags, tags::art());
-        collection::add_domain(delegated_witness, &mut collection, tags);
+        collection::add_domain(dw, &mut collection, tags);
 
+        // Setup primary market. Note that this step can also be done
+        // not in the init function but on the client side by calling
+        // the launchpad functions directly
         let listing = nft_protocol::listing::new(
             tx_context::sender(ctx),
             tx_context::sender(ctx),
@@ -100,8 +110,8 @@ module nft_protocol::suitraders {
             ctx,
         );
 
-        transfer::public_transfer(publisher, tx_context::sender(ctx));
-        transfer::public_transfer(mint_cap, tx_context::sender(ctx));
+        transfer::public_transfer(publisher, sender);
+        transfer::public_transfer(mint_cap, sender);
         transfer::public_share_object(listing);
         transfer::public_share_object(collection);
     }

--- a/examples/symbol.move
+++ b/examples/symbol.move
@@ -8,7 +8,6 @@ module nft_protocol::example_symbol {
     use sui::tx_context::{Self, TxContext};
     use sui::vec_set::{Self, VecSet};
 
-    use nft_protocol::mint_cap;
     use nft_protocol::witness;
     use nft_protocol::display_info;
     use nft_protocol::collection::{Self, Collection};
@@ -57,14 +56,10 @@ module nft_protocol::example_symbol {
     // === Contract functions ===
 
     /// Called during contract publishing
-    fun init(_witness: EXAMPLE_SYMBOL, ctx: &mut TxContext) {
+    fun init(_otw: EXAMPLE_SYMBOL, ctx: &mut TxContext) {
         let delegated_witness = witness::from_witness(Witness {});
         let collection: Collection<EXAMPLE_SYMBOL> =
             collection::create(delegated_witness, ctx);
-
-        let mint_cap = mint_cap::new_unlimited(
-            delegated_witness, &collection, ctx,
-        );
 
         collection::add_domain(
             delegated_witness,
@@ -81,7 +76,6 @@ module nft_protocol::example_symbol {
             Registry { symbols: vec_set::empty() },
         );
 
-        transfer::public_transfer(mint_cap, tx_context::sender(ctx));
         transfer::public_share_object(collection);
     }
 

--- a/tests/utils.move
+++ b/tests/utils.move
@@ -1,13 +1,6 @@
 #[test_only]
 module nft_protocol::test_utils {
-    use nft_protocol::mint_cap;
-    use nft_protocol::collection::{Self, Collection};
-    use nft_protocol::witness;
-    use nft_protocol::transfer_allowlist::{Self, Allowlist};
-
-    use sui::object::{Self, UID, ID};
-    use sui::test_scenario::{Self, Scenario, ctx};
-    use sui::transfer::{public_transfer, public_share_object};
+    use sui::object::UID;
 
     struct Foo has key, store {
         id: UID,
@@ -19,42 +12,43 @@ module nft_protocol::test_utils {
         Witness {}
     }
 
-    public fun create_collection_and_allowlist(
-        creator: address,
-        scenario: &mut Scenario,
-    ): (ID, ID, ID) {
-        let delegated_witness = witness::from_witness(Witness {});
+    // TODO: This will be reintroduced
+    // public fun create_collection_and_allowlist(
+    //     creator: address,
+    //     scenario: &mut Scenario,
+    // ): (ID, ID, ID) {
+    //     let delegated_witness = witness::from_witness(Witness {});
 
-        let collection: Collection<Foo> = collection::create(
-            delegated_witness, ctx(scenario),
-        );
+    //     let collection: Collection<Foo> = collection::create(
+    //         delegated_witness, ctx(scenario),
+    //     );
 
-        let mint_cap = mint_cap::new_unlimited(
-            delegated_witness, &collection, ctx(scenario),
-        );
+    //     let mint_cap = mint_cap::new_unlimited(
+    //         delegated_witness, &collection, ctx(scenario),
+    //     );
 
-        let col_id = object::id(&collection);
-        let cap_id = object::id(&mint_cap);
+    //     let col_id = object::id(&collection);
+    //     let cap_id = object::id(&mint_cap);
 
-        public_share_object(collection);
-        test_scenario::next_tx(scenario, creator);
+    //     public_share_object(collection);
+    //     test_scenario::next_tx(scenario, creator);
 
-        transfer_allowlist::init_allowlist(&Witness {}, ctx(scenario));
+    //     transfer_allowlist::init_allowlist(&Witness {}, ctx(scenario));
 
-        test_scenario::next_tx(scenario, creator);
+    //     test_scenario::next_tx(scenario, creator);
 
-        let wl: Allowlist = test_scenario::take_shared(scenario);
-        let wl_id = object::id(&wl);
+    //     let wl: Allowlist = test_scenario::take_shared(scenario);
+    //     let wl_id = object::id(&wl);
 
-        transfer_allowlist::insert_collection<Foo, Witness>(
-            &mut wl,
-            &Witness {},
-            witness::from_witness<Foo, Witness>(Witness {}),
-        );
+    //     transfer_allowlist::insert_collection<Foo, Witness>(
+    //         &mut wl,
+    //         &Witness {},
+    //         witness::from_witness<Foo, Witness>(Witness {}),
+    //     );
 
-        public_transfer(mint_cap, creator);
-        test_scenario::return_shared(wl);
+    //     public_transfer(mint_cap, creator);
+    //     test_scenario::return_shared(wl);
 
-        (col_id, cap_id, wl_id)
-    }
+    //     (col_id, cap_id, wl_id)
+    // }
 }


### PR DESCRIPTION
Currently, the supply of a type is essentially unenforceable, because one can use the `Publisher` or the `DelegatedWitness` at any time to create new MintCaps.

The only way to guarantee that a supply is Capped is to therefore burn or lock the `Publisher`, which is too big of sacrifice, since `Publisher` is also used in the context of other frameworks, and also used on our protocol to get the delegated witness, which the creator needs to manage certain aspects of the collection.

Therefore the `MintCap` object should be at the same level as the `Publisher`, in that it should have to be claimed in the init function. To enforce this we just need to assert the following.