### PR TITLE
Feature: MintSupply

### DIFF
--- a/launchpad_v2/sources/venue.move
+++ b/launchpad_v2/sources/venue.move
@@ -12,7 +12,7 @@ module launchpad_v2::venue {
     use sui::transfer;
 
     use nft_protocol::witness;
-    use nft_protocol::supply::{Self, Supply};
+    use nft_protocol::utils_supply::{Self, Supply};
     use launchpad_v2::launchpad::{Self, LaunchCap};
     use launchpad_v2::request::{Self, Request as AuthRequest, PolicyCap as AuthPolicyCap, Policy as AuthPolicy};
     use launchpad_v2::proceeds::{Self, Proceeds};
@@ -314,7 +314,7 @@ module launchpad_v2::venue {
         assert_called_from_market<AW>(venue);
 
         if (option::is_some(&venue.supply)) {
-            supply::decrement(option::borrow_mut(&mut venue.supply), quantity);
+            utils_supply::decrement(option::borrow_mut(&mut venue.supply), quantity);
         }
     }
 

--- a/sources/collection/mint_pass.move
+++ b/sources/collection/mint_pass.move
@@ -19,7 +19,7 @@ module nft_protocol::mint_pass {
     use sui::dynamic_field as df;
 
     use nft_protocol::mint_cap::{Self, MintCap};
-    use nft_protocol::supply::{Self, Supply};
+    use nft_protocol::utils_supply::{Self, Supply};
 
     /// `MintCap` is unregulated when expected regulated
     const EMINT_CAP_UNREGULATED: u64 = 1;
@@ -56,8 +56,7 @@ module nft_protocol::mint_pass {
 
         MintPass {
             id: object::new(ctx),
-            // The supply is always set to frozen for safety
-            supply: supply::new(supply, true),
+            supply: utils_supply::new(supply),
         }
     }
 
@@ -70,8 +69,7 @@ module nft_protocol::mint_pass {
 
         MintPass {
             id: object::new(ctx),
-            // The supply is always set to frozen for safety
-            supply: supply::new(supply, true),
+            supply: utils_supply::new(supply),
         }
     }
 
@@ -113,12 +111,7 @@ module nft_protocol::mint_pass {
     ///
     /// Panics if supply is unregulated.
     public fun supply<T>(mint_pass: &MintPass<T>): u64 {
-        supply::get_current(&mint_pass.supply)
-    }
-
-    public fun is_frozen<T>(mint_pass: &MintPass<T>): bool {
-        let supply = get_supply(mint_pass);
-        supply::is_frozen(supply)
+        utils_supply::get_current(&mint_pass.supply)
     }
 
     public fun get_supply<T>(mint_pass: &MintPass<T>): &Supply {
@@ -142,7 +135,7 @@ module nft_protocol::mint_pass {
         mint_pass: &mut MintPass<T>,
         quantity: u64,
     ) {
-        supply::increment(&mut mint_pass.supply, quantity);
+        utils_supply::increment(&mut mint_pass.supply, quantity);
     }
 
     /// Create a new `MintCap` by delegating supply from unregulated or
@@ -156,7 +149,7 @@ module nft_protocol::mint_pass {
 
         MintPass {
             id: object::new(ctx),
-            supply: supply::new(supply, true),
+            supply: utils_supply::new(supply),
         }
     }
 
@@ -168,7 +161,7 @@ module nft_protocol::mint_pass {
     ) {
         let MintPass { id, supply } = other;
 
-        supply::merge(
+        utils_supply::merge(
             &mut mint_pass.supply,
             supply,
         );

--- a/sources/standards/mint_supply.move
+++ b/sources/standards/mint_supply.move
@@ -1,0 +1,253 @@
+/// Module of collection `MintSupply`
+///
+/// A `Collection` can choose to regulate the supply of multiple NFT types
+/// that it defines at the global mint level, by registering a `MintSupply<T>`.
+///
+/// Collections can have a ceiling on the maximum supply and keep track
+/// of the current supply, whilst unregulated policies have no supply
+/// constraints nor they keep track of the number of minted objects.
+module nft_protocol::mint_supply {
+    use sui::transfer;
+    use sui::object::UID;
+    use sui::dynamic_field as df;
+    use sui::tx_context::TxContext;
+
+    use nft_protocol::utils::{Self, Marker};
+    use nft_protocol::mint_cap::{Self, MintCap};
+    use nft_protocol::utils_supply::{Self, Supply};
+
+    /// `MintSupply` was not defined
+    ///
+    /// Call `mint_supply::add_domain` to add `MintSupply`.
+    const EUndefinedMintSupply: u64 = 1;
+
+    /// `MintSupply` already defined
+    ///
+    /// Call `mint_supply::borrow_domain` to borrow domain.
+    const EExistingMintSupply: u64 = 2;
+
+    /// `MintSupply` was frozen
+    const ESupplyFrozen: u64 = 3;
+
+    /// `MintSupply` was not frozen
+    const ESupplyNotFrozen: u64 = 4;
+
+    /// `MintSupply` provides the source of truth of the total supply and
+    /// delegated mint rights.
+    struct MintSupply<phantom T> has store {
+        frozen: bool,
+        mint_cap: MintCap<T>,
+        supply: Supply,
+    }
+
+    /// Creates a `MintSupply`
+    ///
+    /// `MintCap<T>` should be unique for the entire contract.
+    ///
+    /// Total quantity that can be delegated is bounded by the underlying
+    /// `MintCap<T>`, it is recommended to construct `MintSupply<T>` using
+    /// an unregulated `MintCap<T>`.
+    public fun new<T>(
+        mint_cap: MintCap<T>,
+        supply: u64,
+        frozen: bool,
+    ): MintSupply<T> {
+        MintSupply {
+            frozen,
+            mint_cap,
+            supply: utils_supply::new(supply),
+        }
+    }
+
+    /// Return the backing `Supply`
+    public fun get_supply<T>(supply: &MintSupply<T>): &Supply {
+        &supply.supply
+    }
+
+    /// Return whether the `MintSupply` is frozen
+    public fun is_frozen<T>(supply: &MintSupply<T>): bool {
+        supply.frozen
+    }
+
+    /// Delete a `MintSupply<T>` recovering the underlying `MintCap<T>`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if collection is unregulated or supply is non-zero or frozen.
+    public fun delete<T>(supply: MintSupply<T>): MintCap<T> {
+        assert_not_frozen(&supply);
+        let MintSupply<T> { mint_cap, supply: _, frozen: _ } = supply;
+
+        mint_cap
+    }
+
+    /// Freeze the supply of `MintSupply<T>`
+    ///
+    /// Will not allow the maximum supply to be increased or decreased, nor
+    /// allow `MintSupply<T>` to be deconstructed.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if collection is unregulated or supply was already frozen.
+    public fun freeze_supply<T>(supply: &mut MintSupply<T>) {
+        supply.frozen = true;
+    }
+
+    /// Delegate a `MintCap<T>` which will be accouted for in the
+    /// `MintSupply<T>`
+    ///
+    /// #### Panics
+    ///
+    /// Panics if maximum supply will be exceeded.
+    public fun delegate<T>(
+        supply: &mut MintSupply<T>,
+        quantity: u64,
+        ctx: &mut TxContext,
+    ): MintCap<T> {
+        utils_supply::increment(&mut supply.supply, quantity);
+        mint_cap::split(&mut supply.mint_cap, quantity, ctx)
+    }
+
+    /// Delegate a `MintCap<T>` which will be accouted for in the
+    /// `MintSupply<T>` and transfer to receiver.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if maximum supply will be exceeded.
+    public fun delegate_and_transfer<T>(
+        supply: &mut MintSupply<T>,
+        quantity: u64,
+        receiver: address,
+        ctx: &mut TxContext,
+    ) {
+        let delegated = delegate(supply, quantity, ctx);
+        transfer::public_transfer(delegated, receiver);
+    }
+
+    /// Merge delegated `RegulatedMintCap`
+    ///
+    /// Any excess supply on the merged `RegulatedMintCap` will be decremented
+    /// from the original `Supply`.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if collection is unregulated.
+    public fun merge_delegated<T>(
+        supply: &mut MintSupply<T>,
+        delegated: MintCap<T>,
+    ) {
+        utils_supply::decrement(&mut supply.supply, mint_cap::supply(&delegated));
+        mint_cap::merge(&mut supply.mint_cap, delegated);
+    }
+
+    /// Increases maximum supply
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is frozen.
+    public fun increase_max_supply<T>(
+        supply: &mut MintSupply<T>,
+        value: u64,
+    ) {
+        assert_not_frozen(supply);
+        utils_supply::increase_maximum(&mut supply.supply, value)
+    }
+
+    /// Decreases maximum supply
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is frozen or if new maximum supply is smaller than
+    /// current supply.
+    public fun decrease_max_supply<T>(
+        supply: &mut MintSupply<T>,
+        value: u64
+    ) {
+        assert_not_frozen(supply);
+        utils_supply::decrease_maximum(&mut supply.supply, value)
+    }
+
+    // === Interoperability ===
+
+    /// Returns whether `MintSupply` is registered on collection
+    public fun has_domain<T>(collection: &UID): bool {
+        df::exists_with_type<Marker<MintSupply<T>>, MintSupply<T>>(
+            collection, utils::marker(),
+        )
+    }
+
+    /// Borrows `MintSupply` from collection
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `MintSupply` is not registered on the collection
+    public fun borrow_domain<T>(collection: &UID): &MintSupply<T> {
+        assert_regulated<T>(collection);
+        df::borrow(collection, utils::marker<MintSupply<T>>())
+    }
+
+    /// Mutably borrows `MintSupply` from collection
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `MintSupply` is not registered on the collection
+    public fun borrow_domain_mut<T>(
+        collection: &mut UID,
+    ): &mut MintSupply<T> {
+        assert_regulated<T>(collection);
+        df::borrow_mut(collection, utils::marker<MintSupply<T>>())
+    }
+
+    /// Adds `MintSupply` to collection
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `MintSupply` domain already exists
+    public fun add_domain<T>(
+        collection: &mut UID,
+        domain: MintSupply<T>,
+    ) {
+        assert_unregulated<T>(collection);
+        df::add(collection, utils::marker<MintSupply<T>>(), domain);
+    }
+
+    /// Remove `MintSupply` from collection
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `MintSupply` domain doesnt exist
+    public fun remove_domain<T>(collection: &mut UID): MintSupply<T> {
+        assert_regulated<T>(collection);
+        df::remove(collection, utils::marker<MintSupply<T>>())
+    }
+
+    // === Assertions ===
+
+    /// Asserts that `MintSupply` is registered on collection
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `MintSupply` is not registered
+    public fun assert_regulated<T>(collection: &UID) {
+        assert!(has_domain<T>(collection), EUndefinedMintSupply);
+    }
+
+    /// Asserts that `MintSupply` is not registered on collection
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `MintSupply` is registered
+    public fun assert_unregulated<T>(collection: &UID) {
+        assert!(!has_domain<T>(collection), EExistingMintSupply);
+    }
+
+    /// Assert that `MintSupply` is frozen
+    public fun assert_frozen<T>(domain: &MintSupply<T>) {
+        assert!(is_frozen(domain), ESupplyNotFrozen)
+    }
+
+    /// Assert that `MintSupply` not is frozen
+    public fun assert_not_frozen<T>(domain: &MintSupply<T>) {
+        assert!(!is_frozen(domain), ESupplyFrozen)
+    }
+}

--- a/sources/standards/supply.move
+++ b/sources/standards/supply.move
@@ -170,7 +170,7 @@ module nft_protocol::supply {
     ///
     /// Panics if new maximum supply exceeds maximum.
     public fun increment<T>(
-        witness: DelegatedWitness<T>,
+        _witness: DelegatedWitness<T>,
         supply: &mut Supply<T>,
         value: u64
     ) {
@@ -189,7 +189,7 @@ module nft_protocol::supply {
     ///
     /// Panics if new maximum supply exceeds maximum.
     public fun decrement<T>(
-        witness: DelegatedWitness<T>,
+        _witness: DelegatedWitness<T>,
         supply: &mut Supply<T>,
         value: u64
     ) {

--- a/sources/standards/supply.move
+++ b/sources/standards/supply.move
@@ -10,186 +10,116 @@
 /// of the current supply, whilst unregulated policies have no supply
 /// constraints nor they keep track of the number of minted objects.
 module nft_protocol::supply {
-    use nft_protocol::err;
+    use nft_protocol::utils::{Self, Marker};
+    use nft_protocol::utils_supply;
+    use nft_protocol::witness::Witness as DelegatedWitness;
 
     use sui::object::UID;
     use sui::dynamic_field as df;
 
-    friend nft_protocol::warehouse;
+    /// `Supply` was not defined
+    ///
+    /// Call `supply::add_domain` or to add `Supply`.
+    const EUndefinedSupply: u64 = 1;
 
-    /// No field object `Attributes` defined as a dynamic field.
-    const EUNDEFINED_SUPPLY_FIELD: u64 = 1;
+    /// `Supply` already defined
+    ///
+    /// Call `supply::borrow_domain` to borrow domain.
+    const EExistingSupply: u64 = 2;
 
-    /// Field object `Attributes` already defined as dynamic field.
-    const ESUPPLY_FIELD_ALREADY_EXISTS: u64 = 2;
+    /// `Supply` is frozen
+    const ESupplyFrozen: u64 = 3;
 
-
-    /// `Supply` tracks supply parameters
+    /// `Supply` tracks supply parameters for type `T`
     ///
     /// `Supply` can be frozen, therefore making it impossible to change the
     /// maximum supply.
-    struct Supply has store, drop {
+    struct Supply<phantom T> has store, drop {
         frozen: bool,
-        max: u64,
-        current: u64,
+        inner: utils_supply::Supply,
     }
-
-    /// Witness used to authenticate witness protected endpoints
-    struct Witness has drop {}
-
-    /// Key struct used to store Attributes in dynamic fields
-    struct SupplyKey has store, copy, drop {}
-
-
-    // === Insert with module specific Witness ===
-
-
-    /// Adds `Supply` as a dynamic field with key `SupplyKey`.
-    ///
-    /// Endpoint is protected as it relies on safetly obtaining a witness
-    /// from the contract exporting the type `T`.
-    ///
-    /// #### Panics
-    ///
-    /// Panics if `object_uid` does not correspond to `object_type.id`,
-    /// in other words, it panics if `object_uid` is not of type `T`.
-    ///
-    /// Panics if Witness `W` does not match `T`'s module.
-    public fun add_supply<T: key>(
-        object_uid: &mut UID,
-        max: u64,
-        frozen: bool,
-    ) {
-        assert_has_not_supply(object_uid);
-
-        let supply = new(max, frozen);
-        df::add(object_uid, SupplyKey {}, supply);
-    }
-
-
-    // === Get for call from external Module ===
-
 
     /// Creates a new `Supply`
-    public fun new(max: u64, frozen: bool): Supply {
-        Supply { frozen: frozen, max: max, current: 0 }
+    public fun new<T>(max: u64, frozen: bool): Supply<T> {
+        Supply { frozen, inner: utils_supply::new(max) }
     }
 
-
-    // === Field Borrow Functions ===
-
-
-    /// Borrows immutably the `Supply` field.
-    ///
-    /// #### Panics
-    ///
-    /// Panics if dynamic field with `SupplyKey` does not exist.
-    public fun borrow_supply(
-        object_uid: &UID,
-    ): &Supply {
-        // `df::borrow` fails if there is no such dynamic field,
-        // however asserting it here allows for a more straightforward
-        // error message
-        assert_has_supply(object_uid);
-        df::borrow(object_uid, SupplyKey {})
+    /// Borrows the underlying supply object
+    public fun borrow_inner<T>(supply: &Supply<T>): &utils_supply::Supply {
+        &supply.inner
     }
-
-    /// Borrows Mutably the `Supply` field.
-    ///
-    /// Endpoint is protected as it relies on safetly obtaining a witness
-    /// from the contract exporting the type `T`.
-    ///
-    /// #### Panics
-    ///
-    /// Panics if dynamic field with `SupplyKey` does not exist.
-    ///
-    /// Panics if `object_uid` does not correspond to `object_type.id`,
-    /// in other words, it panics if `object_uid` is not of type `T`.
-    ///
-    /// Panics if Witness `W` does not match `T`'s module.
-    public fun borrow_supply_mut<T: key>(
-        object_uid: &mut UID,
-    ): &mut Supply {
-        // `df::borrow` fails if there is no such dynamic field,
-        // however asserting it here allows for a more straightforward
-        // error message
-        assert_has_supply(object_uid);
-
-        df::borrow_mut(object_uid, SupplyKey {})
-    }
-
 
     // === Writer Functions ===
 
-
-    /// Increases maximum supply in `Supply` field in the object of type `T`
+    /// Increases maximum for `Supply<T>`
     ///
     /// Endpoint is protected as it relies on safetly obtaining a witness
     /// from the contract exporting the type `T`.
     ///
     /// #### Panics
     ///
-    /// Panics if dynamic field with `AttributesKey` does not exist.
-    ///
-    /// Panics if `nft_uid` does not correspond to `nft_type.id`,
-    /// in other words, it panics if `nft_uid` is not of type `T`.
-    ///
-    /// Panics if Witness `W` does not match `T`'s module.
-    ///
-    /// Panics if supply is frozen.
-    public fun increase_supply_ceil<T: key>(
-        object_uid: &mut UID,
+    /// Panics if `Supply<T>` is frozen.
+    public fun increase_supply_ceil<T>(
+        _witness: DelegatedWitness<T>,
+        supply: &mut Supply<T>,
         value: u64,
     ) {
-        // `df::borrow` fails if there is no such dynamic field,
-        // however asserting it here allows for a more straightforward
-        // error message
-        assert_has_supply(object_uid);
-
-        let supply = df::borrow_mut<SupplyKey, Supply>(
-            object_uid,
-            SupplyKey {}
-        );
-
         assert_not_frozen(supply);
-        supply.max = supply.max + value;
+        utils_supply::increase_maximum(&mut supply.inner, value)
     }
 
-    /// Decreases maximum supply in `Supply` field in the object of type `T`
+    /// Increases maximum for `Supply<T>`
     ///
     /// Endpoint is protected as it relies on safetly obtaining a witness
     /// from the contract exporting the type `T`.
     ///
     /// #### Panics
     ///
-    /// Panics if dynamic field with `AttributesKey` does not exist.
-    ///
-    /// Panics if `nft_uid` does not correspond to `nft_type.id`,
-    /// in other words, it panics if `nft_uid` is not of type `T`.
-    ///
-    /// Panics if Witness `W` does not match `T`'s module.
-    ///
-    /// Panics if value is supperior to current supply.
-    public fun decrease_supply_ceil<T: key>(
-        object_uid: &mut UID,
+    /// Panics if `Supply<T>` is not defined on object or is frozen.
+    public fun increase_supply_ceil_nft<T>(
+        witness: DelegatedWitness<T>,
+        object: &mut UID,
         value: u64,
     ) {
-        // `df::borrow` fails if there is no such dynamic field,
-        // however asserting it here allows for a more straightforward
-        // error message
-        assert_has_supply(object_uid);
+        let supply = borrow_domain_mut(object);
+        increase_supply_ceil(witness, supply, value);
+    }
 
-        let supply = df::borrow_mut<SupplyKey, Supply>(
-            object_uid,
-            SupplyKey {}
-        );
-
+    /// Decreases maximum for `Supply<T>`
+    ///
+    /// Endpoint is protected as it relies on safetly obtaining a witness
+    /// from the contract exporting the type `T`.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply<T>` is frozen or maximum supply would become lower
+    /// than current supply.
+    public fun decrease_supply_ceil<T>(
+        _witness: DelegatedWitness<T>,
+        supply: &mut Supply<T>,
+        value: u64,
+    ) {
         assert_not_frozen(supply);
-        assert!(
-            supply.max - value > supply.current,
-            err::max_supply_cannot_be_below_current_supply()
-        );
-        supply.max = supply.max - value;
+        utils_supply::decrease_maximum(&mut supply.inner, value)
+    }
+
+    /// Decreases maximum for `Supply<T>`
+    ///
+    /// Endpoint is protected as it relies on safetly obtaining a witness
+    /// from the contract exporting the type `T`.
+    ///
+    /// #### Panics
+    ///
+    /// - `Supply<T>` is not defined
+    /// - Supply is frozen
+    /// - Maximum supply would become lower than current supply
+    public fun decrease_supply_ceil_nft<T>(
+        witness: DelegatedWitness<T>,
+        object: &mut UID,
+        value: u64,
+    ) {
+        let supply = borrow_domain_mut(object);
+        decrease_supply_ceil(witness, supply, value)
     }
 
     /// Freezes supply in `Supply` field in the object of type `T`
@@ -199,104 +129,59 @@ module nft_protocol::supply {
     ///
     /// #### Panics
     ///
-    /// Panics if dynamic field with `AttributesKey` does not exist.
-    ///
-    /// Panics if `object_uid` does not correspond to `object_type.id`,
-    /// in other words, it panics if `object_uid` is not of type `T`.
-    ///
-    /// Panics if supply is frozen already.
-    public fun freeze_supply<T: key>(
-        object_uid: &mut UID,
+    /// Panics if `Supply<T>` is already frozen.
+    public fun freeze_supply<T>(
+        _witness: DelegatedWitness<T>,
+        supply: &mut Supply<T>,
     ) {
-        // `df::borrow` fails if there is no such dynamic field,
-        // however asserting it here allows for a more straightforward
-        // error message
-        assert_has_supply(object_uid);
-
-        let supply = df::borrow_mut<SupplyKey, Supply>(
-            object_uid,
-            SupplyKey {}
-        );
-
         assert_not_frozen(supply);
         supply.frozen = true;
     }
 
+    /// Freezes supply in `Supply` field in the object of type `T`
+    ///
+    /// Endpoint is protected as it relies on safetly obtaining a witness
+    /// from the contract exporting the type `T`.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply<T>` is not defined or is already frozen.
+    public fun freeze_supply_nft<T>(
+        witness: DelegatedWitness<T>,
+        object: &mut UID,
+    ) {
+        let supply = borrow_domain_mut(object);
+        freeze_supply(witness, supply)
+    }
 
-    // === Getter Functions & Static Mutability Accessors ===
-
-
-    /// Increments current supply. This function should be called when an NFT
-    /// is minted, if it's type has a supply.
+    /// Increments current supply.
+    ///
+    /// This function should be called when an NFT is minted, if it's type has
+    /// a supply.
     ///
     /// Endpoint is unprotected as it relies on safetly obtaining a mutable
-    /// reference to `Attributes`.
+    /// reference to `Supply<T>`.
     ///
     /// #### Panics
     ///
     /// Panics if new maximum supply exceeds maximum.
-    public fun increment(supply: &mut Supply, value: u64) {
-        assert!(
-            supply.current + value <= supply.max,
-            err::supply_maxed_out()
-        );
-        supply.current = supply.current + value;
+    public fun increment<T>(supply: &mut Supply<T>, value: u64) {
+        utils_supply::increment(&mut supply.inner, value)
     }
 
-    /// Decrements current supply. This function should be called when an NFT
-    /// is burned, if it's type has a supply.
+    /// Decrements current supply.
+    ///
+    /// This function should be called when an NFT is minted, if it's type has
+    /// a supply.
     ///
     /// Endpoint is unprotected as it relies on safetly obtaining a mutable
-    /// reference to `Attributes`.
+    /// reference to `Supply<T>`.
     ///
     /// #### Panics
     ///
     /// Panics if new maximum supply exceeds maximum.
-    public fun decrement(supply: &mut Supply, value: u64) {
-        supply.current = supply.current - value;
-    }
-
-    /// Freezes supply in `Supply` field object.
-    ///
-    /// Endpoint is unprotected as it relies on safetly obtaining a mutable
-    /// reference to `Attributes`.
-    ///
-    /// #### Panics
-    ///
-    /// Panics if already frozen
-    public fun freeze_supply_(supply: &mut Supply) {
-        assert_not_frozen(supply);
-        supply.frozen = true;
-    }
-
-    // TODO: Is the name not duplicated?
-    /// Increases maximum supply
-    ///
-    /// Endpoint is unprotected as it relies on safetly obtaining a mutable
-    /// reference to `Attributes`.
-    ///
-    /// #### Panics
-    ///
-    /// Panics if supply is frozen.
-    public fun increase_supply_ceil_(supply: &mut Supply, value: u64) {
-        assert_not_frozen(supply);
-        supply.max = supply.max + value;
-    }
-
-    // TODO: Is the name not duplicated?
-    /// Decreases maximum supply
-    ///
-    /// #### Panics
-    ///
-    /// Panics if supply is frozen or if new maximum supply is smaller than
-    /// current supply.
-    public fun decrease_supply_ceil_(supply: &mut Supply, value: u64) {
-        assert_not_frozen(supply);
-        assert!(
-            supply.max - value > supply.current,
-            err::max_supply_cannot_be_below_current_supply()
-        );
-        supply.max = supply.max - value;
+    public fun decrement<T>(supply: &mut Supply<T>, value: u64) {
+        utils_supply::decrement(&mut supply.inner, value)
     }
 
     /// Merge two `Supply` to one
@@ -312,80 +197,150 @@ module nft_protocol::supply {
     ///
     /// Panics if total supply will cause maximum or zero supply to be
     /// exceeded.
-    public fun merge(supply: &mut Supply, other: Supply) {
-        let excess = other.max - other.current;
-        decrement(supply, excess);
-        increment(supply, other.current);
+    public fun merge<T>(supply: &mut Supply<T>, other: Supply<T>) {
+        let other = delete(other);
+        utils_supply::merge(&mut supply.inner, other);
     }
 
     /// Split one `Supply` into two.
     ///
     /// #### Panics
     ///
-    /// Panics if `split_max` is superior to `Supply.max`
-    /// Panics if `split_current` is superior to `Supply.current`
-    /// Panics if the result leads to `current > max`
-    public fun split(
-        supply: &mut Supply,
+    /// Panics if `split_max` is larger remaining supply
+    public fun split<T>(
+        supply: &mut Supply<T>,
         split_max: u64,
-    ): Supply {
-        decrease_supply_ceil_(supply, split_max);
-        let new_supply = new(split_max, false);
-
-        new_supply
-    }
-
-    /// Returns maximum supply
-    public fun get_max(supply: &Supply): u64 {
-        supply.max
-    }
-
-    /// Returns current supply
-    public fun get_current(supply: &Supply): u64 {
-        supply.current
+    ): Supply<T> {
+        let inner = utils_supply::split(&mut supply.inner, split_max);
+        Supply { frozen: true, inner }
     }
 
     /// Returns `true` if frozen
-    public fun is_frozen(supply: &Supply): bool {
+    public fun is_frozen<T>(supply: &Supply<T>): bool {
         supply.frozen
     }
 
+    /// Returns maximum supply
+    public fun get_max<T>(supply: &Supply<T>): u64 {
+        utils_supply::get_max(&supply.inner)
+    }
+
+    /// Returns current supply
+    public fun get_current<T>(supply: &Supply<T>): u64 {
+        utils_supply::get_current(&supply.inner)
+    }
+
     /// Returns remaining supply
-    public fun get_remaining_supply(supply: &Supply): u64 {
-        supply.max - supply.current
+    public fun get_remaining<T>(supply: &Supply<T>): u64 {
+        utils_supply::get_remaining(&supply.inner)
     }
 
+    // === Interoperability ===
 
-    // === Assertions & Helpers ===
-
-
-    /// Checks that a given NFT has a dynamic field with `AttributesKey`
-    public fun has_supply(
-        object_uid: &UID,
-    ): bool {
-        df::exists_(object_uid, SupplyKey {})
+    /// Returns whether `Supply` is registered on object
+    public fun has_domain<T>(nft: &UID): bool {
+        df::exists_with_type<Marker<Supply<T>>, Supply<T>>(
+            nft, utils::marker(),
+        )
     }
+
+    /// Borrows `Supply` from object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` is not registered on the object
+    public fun borrow_domain<T>(nft: &UID): &Supply<T> {
+        assert_supply<T>(nft);
+        df::borrow(nft, utils::marker<Supply<T>>())
+    }
+
+    /// Mutably borrows `Supply` from object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` is not registered on the object
+    public fun borrow_domain_mut<T>(nft: &mut UID): &mut Supply<T> {
+        assert_supply<T>(nft);
+        df::borrow_mut(nft, utils::marker<Supply<T>>())
+    }
+
+    /// Adds `Supply` to object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` domain already exists
+    public fun add_domain<T>(
+        nft: &mut UID,
+        domain: Supply<T>,
+    ) {
+        assert_no_supply<T>(nft);
+        df::add(nft, utils::marker<Supply<T>>(), domain);
+    }
+
+    /// Adds new `Supply` to object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` domain already exists
+    public fun add_new<T>(
+        nft: &mut UID,
+        max: u64,
+        frozen: bool,
+    ) {
+        add_domain(nft, new<T>(max, frozen))
+    }
+
+    /// Remove `Supply` from object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` domain doesnt exist
+    public fun remove_domain<T>(nft: &mut UID): Supply<T> {
+        assert_supply<T>(nft);
+        df::remove(nft, utils::marker<Supply<T>>())
+    }
+
+    /// Delete `Supply`
+    public fun delete<T>(supply: Supply<T>): utils_supply::Supply {
+        let Supply { frozen: _, inner } = supply;
+        inner
+    }
+
+    // === Assertions ===
 
     /// Asserts that current supply is zero
-    public fun assert_zero_current_supply(supply: &Supply) {
-        assert!(supply.current == 0, err::supply_is_not_zero())
-    }
-
-    /// Asserts that supply is frozen
-    public fun assert_frozen(supply: &Supply) {
-        assert!(supply.frozen, err::supply_not_frozen())
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is non-zero.
+    public fun assert_zero<T>(supply: &Supply<T>) {
+        utils_supply::assert_zero(&supply.inner)
     }
 
     /// Asserts that supply is not frozen
-    public fun assert_not_frozen(supply: &Supply) {
-        assert!(!supply.frozen, err::supply_frozen())
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is not frozen.
+    public fun assert_not_frozen<T>(supply: &Supply<T>) {
+        assert!(!supply.frozen, ESupplyFrozen)
     }
 
-    public fun assert_has_supply(object_uid: &UID) {
-        assert!(has_supply(object_uid), EUNDEFINED_SUPPLY_FIELD);
+    /// Asserts that `Supply` is registered on object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` is not registered
+    public fun assert_supply<T>(nft: &UID) {
+        assert!(has_domain<T>(nft), EUndefinedSupply);
     }
 
-    public fun assert_has_not_supply(object_uid: &UID) {
-        assert!(!has_supply(object_uid), ESUPPLY_FIELD_ALREADY_EXISTS);
+    /// Asserts that `Supply` is not registered on object
+    ///
+    /// #### Panics
+    ///
+    /// Panics if `Supply` is registered
+    public fun assert_no_supply<T>(nft: &UID) {
+        assert!(!has_domain<T>(nft), EExistingSupply);
     }
 }

--- a/sources/standards/supply.move
+++ b/sources/standards/supply.move
@@ -40,7 +40,11 @@ module nft_protocol::supply {
     }
 
     /// Creates a new `Supply`
-    public fun new<T>(max: u64, frozen: bool): Supply<T> {
+    public fun new<T>(
+        _witness: DelegatedWitness<T>,
+        max: u64,
+        frozen: bool
+    ): Supply<T> {
         Supply { frozen, inner: utils_supply::new(max) }
     }
 
@@ -165,7 +169,11 @@ module nft_protocol::supply {
     /// #### Panics
     ///
     /// Panics if new maximum supply exceeds maximum.
-    public fun increment<T>(supply: &mut Supply<T>, value: u64) {
+    public fun increment<T>(
+        witness: DelegatedWitness<T>,
+        supply: &mut Supply<T>,
+        value: u64
+    ) {
         utils_supply::increment(&mut supply.inner, value)
     }
 
@@ -180,7 +188,11 @@ module nft_protocol::supply {
     /// #### Panics
     ///
     /// Panics if new maximum supply exceeds maximum.
-    public fun decrement<T>(supply: &mut Supply<T>, value: u64) {
+    public fun decrement<T>(
+        witness: DelegatedWitness<T>,
+        supply: &mut Supply<T>,
+        value: u64
+    ) {
         utils_supply::decrement(&mut supply.inner, value)
     }
 
@@ -283,11 +295,12 @@ module nft_protocol::supply {
     ///
     /// Panics if `Supply` domain already exists
     public fun add_new<T>(
-        nft: &mut UID,
+        witness: DelegatedWitness<T>,
+        object: &mut UID,
         max: u64,
         frozen: bool,
     ) {
-        add_domain(nft, new<T>(max, frozen))
+        add_domain(object, new<T>(witness, max, frozen))
     }
 
     /// Remove `Supply` from object
@@ -295,9 +308,9 @@ module nft_protocol::supply {
     /// #### Panics
     ///
     /// Panics if `Supply` domain doesnt exist
-    public fun remove_domain<T>(nft: &mut UID): Supply<T> {
-        assert_supply<T>(nft);
-        df::remove(nft, utils::marker<Supply<T>>())
+    public fun remove_domain<T>(object: &mut UID): Supply<T> {
+        assert_supply<T>(object);
+        df::remove(object, utils::marker<Supply<T>>())
     }
 
     /// Delete `Supply`

--- a/sources/utils/err.move
+++ b/sources/utils/err.move
@@ -3,28 +3,6 @@
 module nft_protocol::err {
     const Prefix: u64 = 13370000;
 
-    // === Supply ===
-
-    public fun supply_is_not_zero(): u64 {
-        return Prefix + 102
-    }
-
-    public fun supply_frozen(): u64 {
-        return Prefix + 104
-    }
-
-    public fun supply_not_frozen(): u64 {
-        return Prefix + 105
-    }
-
-    public fun max_supply_cannot_be_below_current_supply(): u64 {
-        return Prefix + 106
-    }
-
-    public fun supply_maxed_out(): u64 {
-        return Prefix + 107
-    }
-
     // === Marketplace ===
 
     public fun wrong_marketplace_admin(): u64 {
@@ -71,62 +49,6 @@ module nft_protocol::err {
 
     public fun order_price_below_reserve(): u64 {
         return Prefix + 303
-    }
-
-    // === Kiosk ===
-
-    public fun safe_cap_mismatch(): u64 {
-        return Prefix + 400
-    }
-
-    public fun safe_does_not_contain_nft(): u64 {
-        return Prefix + 401
-    }
-
-    public fun nft_exclusively_listed(): u64 {
-        return Prefix + 402
-    }
-
-    public fun transfer_cap_nft_mismatch(): u64 {
-        return Prefix + 403
-    }
-
-    public fun transfer_cap_expired(): u64 {
-        return Prefix + 404
-    }
-
-    public fun safe_does_not_accept_deposits(): u64 {
-        return Prefix + 405
-    }
-
-    public fun nft_not_exclusively_listed(): u64 {
-        return Prefix + 406
-    }
-
-    public fun safe_id_mismatch(): u64 {
-        return Prefix + 407
-    }
-
-    public fun generic_nft_must_not_be_protocol_type(): u64 {
-        return Prefix + 408
-    }
-
-    public fun nft_is_generic(): u64 {
-        return Prefix + 409
-    }
-
-    public fun cannot_trade_with_self(): u64 {
-        return Prefix + 410
-    }
-
-    // === Utils ===
-
-    public fun witness_source_mismatch(): u64 {
-        return Prefix + 600
-    }
-
-    public fun must_be_witness(): u64 {
-        return Prefix + 601
     }
 
     // === Trading ===

--- a/sources/utils/supply.move
+++ b/sources/utils/supply.move
@@ -1,0 +1,120 @@
+/// Module containing a utility `Supply` type
+///
+/// `Supply` is an unprotected type tracking the current supply and enforcing a
+/// maximum limit.
+module nft_protocol::utils_supply {
+    /// Could not increment supply due to breached limit
+    const EExceededSupply: u64 = 1;
+
+    /// Cannot set minimum supply below the current issued supply
+    const EInvalidMinimumSupply: u64 = 2;
+
+    /// Current issued supply was non-zero
+    const ENonZeroSupply: u64 = 3;
+
+    /// `Supply` tracks supply parameters
+    struct Supply has store, drop {
+        max: u64,
+        current: u64,
+    }
+
+    /// Creates a new `Supply` object
+    public fun new(max: u64): Supply {
+        Supply { max, current: 0 }
+    }
+
+    /// Maximum supply
+    public fun get_max(supply: &Supply): u64 {
+        supply.max
+    }
+
+    /// Current supply
+    public fun get_current(supply: &Supply): u64 {
+        supply.current
+    }
+
+    /// Return remaining supply
+    public fun get_remaining(supply: &Supply): u64 {
+        supply.max - supply.current
+    }
+
+    /// Increases maximum supply
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is frozen.
+    public fun increase_maximum(supply: &mut Supply, value: u64) {
+        supply.max = supply.max + value;
+    }
+
+    /// Decreases maximum supply
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is frozen or if new maximum supply is smaller than
+    /// current supply.
+    public fun decrease_maximum(supply: &mut Supply, value: u64) {
+        assert!(
+            supply.max - value > supply.current,
+            EInvalidMinimumSupply,
+        );
+        supply.max = supply.max - value;
+    }
+
+    /// Increments current supply
+    ///
+    /// #### Panics
+    ///
+    /// Panics if new maximum supply exceeds maximum.
+    public fun increment(supply: &mut Supply, value: u64) {
+        assert!(
+            supply.current + value <= supply.max,
+            EExceededSupply,
+        );
+        supply.current = supply.current + value;
+    }
+
+    /// Decrements current supply
+    public fun decrement(supply: &mut Supply, value: u64) {
+        supply.current = supply.current - value;
+    }
+
+    /// Creates a new `Supply` which is split from the current `Supply`
+    ///
+    /// The extend value is used as the maximum supply for the new `Supply`,
+    /// while the current supply of the existing supply is incremented by the
+    /// value.
+    ///
+    /// Existing `Supply` will be automatically frozen if not already frozen.
+    ///
+    /// #### Panics
+    ///
+    /// Panics if not frozen or if value will cause maximum supply to be
+    /// exceeded.
+    public fun split(supply: &mut Supply, value: u64): Supply {
+        decrease_maximum(supply, value);
+        new(value)
+    }
+
+    /// Merge `Supply` into another
+    ///
+    /// Does not require that either `Supply` is frozen, since splitting supply
+    /// requires that both supplies are frozen, thus merging will only make
+    /// sense with frozen supplies.
+    public fun merge(supply: &mut Supply, other: Supply) {
+        let Supply { max, current } = other;
+        increase_maximum(supply, max);
+        increment(supply, current);
+    }
+
+    // === Assertions ===
+
+    /// Asserts that current supply is zero
+    ///
+    /// #### Panics
+    ///
+    /// Panics if supply is non-zero.
+    public fun assert_zero(supply: &Supply) {
+        assert!(supply.current == 0, ENonZeroSupply)
+    }
+}

--- a/sources/utils/utils.move
+++ b/sources/utils/utils.move
@@ -1,6 +1,5 @@
 /// Utility functions
 module nft_protocol::utils {
-    use nft_protocol::err;
     use std::ascii;
     use std::string::{Self, String, utf8, sub_string};
     use std::type_name;
@@ -13,7 +12,6 @@ module nft_protocol::utils {
     use sui::vec_map::{Self, VecMap};
     use sui::tx_context::TxContext;
     use sui::object::{Self, UID};
-
 
     /// Mismatched length of key and value vectors used in `from_vec_to_map`
     const EMismatchedKeyValueLength: u64 = 1;
@@ -133,13 +131,6 @@ module nft_protocol::utils {
         assert!(uid_id == object_id, 0);
     }
 
-    public fun assert_same_package<A, B>() {
-        assert!(
-            get_package<A>() == get_package<B>(),
-            err::witness_source_mismatch()
-        );
-    }
-
     public fun assert_package_publisher<C>(pub: &Publisher) {
         assert!(package::from_package<C>(pub), EPackagePublisherMismatch);
     }
@@ -204,12 +195,6 @@ module nft_protocol::utils {
         };
 
         map
-    }
-
-    /// T mustn't be exported by nft-protocol to avoid unexpected bugs
-    public fun assert_not_nft_protocol_type<T>() {
-        let (t_pkg, _, _) = get_package_module_type<T>();
-        assert!(t_pkg != nft_protocol_package_id(), err::generic_nft_must_not_be_protocol_type());
     }
 
     /// Returns true if T is of type `nft_protocol::nft::Nft`


### PR DESCRIPTION
- Functionally equivalent to `GlobalSupply` but renamed to `MintSupply` which makes more sense in the context of centralizing control of `MintCap` delegation.
- Introduces a helper type `utils_supply::Supply` which is used across different modules
- `supply::Supply` now has functioning protection, currently it's endpoints are unprotected
- Unified `supply` structure and endpoints with rest of codebase
- Removes a bunch of old error definitions :)